### PR TITLE
Support multi-stack synthesis and diff

### DIFF
--- a/bin/svc
+++ b/bin/svc
@@ -7,6 +7,101 @@ const { execSync } = require('child_process');
 
 const program = new Command();
 
+function normalizeDiffMap(diffMap) {
+  const stacks = [];
+  const totals = { added: 0, modified: 0, removed: 0, total: 0 };
+  let hasChanges = false;
+
+  if (!diffMap) {
+    return { stacks, totals, hasChanges };
+  }
+
+  Object.entries(diffMap).forEach(([stackName, diff]) => {
+    if (!diff) {
+      return;
+    }
+
+    const resources = {
+      added: (diff.resources && diff.resources.added) || {},
+      modified: (diff.resources && diff.resources.modified) || {},
+      removed: (diff.resources && diff.resources.removed) || {}
+    };
+
+    const added = (diff.changes && diff.changes.added) ?? Object.keys(resources.added).length;
+    const modified = (diff.changes && diff.changes.modified) ?? Object.keys(resources.modified).length;
+    const removed = (diff.changes && diff.changes.removed) ?? Object.keys(resources.removed).length;
+    const total = (diff.changes && diff.changes.total) ?? added + modified + removed;
+    const stackHasChanges = (diff.hasChanges !== undefined ? diff.hasChanges : total > 0);
+
+    stacks.push({
+      stackName,
+      hasChanges: stackHasChanges,
+      changes: { added, modified, removed, total },
+      resources
+    });
+
+    totals.added += added;
+    totals.modified += modified;
+    totals.removed += removed;
+    hasChanges = hasChanges || stackHasChanges;
+  });
+
+  totals.total = totals.added + totals.modified + totals.removed;
+
+  return { stacks, totals, hasChanges };
+}
+
+function logDiffDetails(logger, diffMap, indent = '   ') {
+  const summary = normalizeDiffMap(diffMap);
+
+  if (summary.stacks.length === 0) {
+    logger.info(`${indent}No infrastructure changes detected`);
+    return summary;
+  }
+
+  summary.stacks.forEach(stack => {
+    logger.info(`${indent}Stack: ${stack.stackName}`);
+    logger.info(`${indent}Changes: ${stack.changes.added} added, ${stack.changes.modified} modified, ${stack.changes.removed} removed`);
+
+    if (stack.hasChanges) {
+      const resources = stack.resources;
+
+      if (Object.keys(resources.added).length > 0) {
+        logger.info(`${indent}Resources to be created:`);
+        Object.entries(resources.added).forEach(([resourceName, resource]) => {
+          logger.info(`${indent}  + ${resourceName} (${resource.type})`);
+        });
+      }
+
+      if (Object.keys(resources.modified).length > 0) {
+        logger.info(`${indent}Resources to be modified:`);
+        Object.entries(resources.modified).forEach(([resourceName, resource]) => {
+          logger.info(`${indent}  ~ ${resourceName} (${resource.type})`);
+        });
+      }
+
+      if (Object.keys(resources.removed).length > 0) {
+        logger.info(`${indent}Resources to be removed:`);
+        Object.entries(resources.removed).forEach(([resourceName, resource]) => {
+          logger.info(`${indent}  - ${resourceName} (${resource.type})`);
+        });
+      }
+
+      if (
+        Object.keys(resources.added).length === 0 &&
+        Object.keys(resources.modified).length === 0 &&
+        Object.keys(resources.removed).length === 0
+      ) {
+        logger.info(`${indent}No resource-level changes detected for this stack`);
+      }
+    } else {
+      logger.info(`${indent}No infrastructure changes detected for this stack`);
+    }
+  });
+
+  return summary;
+}
+
 program
   .name('svc')
   .description('Shinobi Platform CLI')
@@ -306,6 +401,7 @@ program
 
       // Output results
       if (opts.ci) {
+        const diffSummary = normalizeDiffMap(result.data.cdkDiff);
         const plan = {
           service: result.data.resolvedManifest.service,
           environment: options.env,
@@ -314,7 +410,9 @@ program
           binds: result.data.resolvedManifest.binds || [],
           governance: result.data.resolvedManifest.governance || {},
           cdkDiff: result.data.cdkDiff,
+          cdkDiffSummary: diffSummary,
           cloudFormationTemplate: result.data.cloudFormationTemplate,
+          cloudFormationTemplates: result.data.cloudFormationTemplates,
           timestamp: new Date().toISOString()
         };
         console.log(JSON.stringify(plan, null, 2));
@@ -637,50 +735,29 @@ program
 
       // Display diff results
       const cdkDiff = result.data.cdkDiff;
+      const diffSummary = normalizeDiffMap(cdkDiff);
 
       if (opts.ci) {
         console.log(JSON.stringify({
           level: 'info',
           message: 'Diff analysis completed',
-          stackName: cdkDiff.stackName,
-          changes: cdkDiff.changes,
-          hasChanges: cdkDiff.hasChanges,
-          resources: cdkDiff.resources,
+          hasChanges: diffSummary.hasChanges,
+          totals: diffSummary.totals,
+          stacks: diffSummary.stacks,
           timestamp: new Date().toISOString()
         }));
       } else {
         logger.info('📊 Diff analysis completed');
-        logger.info(`   Stack: ${cdkDiff.stackName}`);
-        logger.info(`   Changes: ${cdkDiff.changes.added} added, ${cdkDiff.changes.modified} modified, ${cdkDiff.changes.removed} removed`);
 
-        if (cdkDiff.hasChanges) {
-          logger.info('\n--- Infrastructure Changes ---');
-
-          if (Object.keys(cdkDiff.resources.added).length > 0) {
-            logger.info('\nResources to be created:');
-            Object.keys(cdkDiff.resources.added).forEach(resourceName => {
-              const resource = cdkDiff.resources.added[resourceName];
-              logger.info(`  + ${resourceName} (${resource.type})`);
-            });
-          }
-
-          if (Object.keys(cdkDiff.resources.modified).length > 0) {
-            logger.info('\nResources to be modified:');
-            Object.keys(cdkDiff.resources.modified).forEach(resourceName => {
-              const resource = cdkDiff.resources.modified[resourceName];
-              logger.info(`  ~ ${resourceName} (${resource.type})`);
-            });
-          }
-
-          if (Object.keys(cdkDiff.resources.removed).length > 0) {
-            logger.info('\nResources to be removed:');
-            Object.keys(cdkDiff.resources.removed).forEach(resourceName => {
-              const resource = cdkDiff.resources.removed[resourceName];
-              logger.info(`  - ${resourceName} (${resource.type})`);
-            });
-          }
-        } else {
+        if (diffSummary.stacks.length === 0) {
           logger.info('   No infrastructure changes detected');
+        } else {
+          logger.info('\n--- Infrastructure Changes ---');
+          logDiffDetails(logger, cdkDiff);
+
+          if (diffSummary.stacks.length > 1) {
+            logger.info(`\n   Total across stacks: ${diffSummary.totals.added} added, ${diffSummary.totals.modified} modified, ${diffSummary.totals.removed} removed`);
+          }
         }
       }
 
@@ -801,69 +878,47 @@ program
       }
 
       const cdkDiff = result.data.cdkDiff;
+      const diffSummary = normalizeDiffMap(cdkDiff);
       const stackName = `${result.data.resolvedManifest.service}-stack`;
+      const stackNames = diffSummary.stacks.map(stack => stack.stackName);
+      const stackDisplayName = stackNames.length > 0 ? stackNames.join(', ') : stackName;
 
       if (options.dryRun) {
         if (opts.ci) {
           console.log(JSON.stringify({
             level: 'info',
             message: 'Dry run completed',
-            stackName: stackName,
-            changes: cdkDiff.changes,
-            hasChanges: cdkDiff.hasChanges,
-            resources: cdkDiff.resources,
+            stackNames,
+            diffSummary,
             timestamp: new Date().toISOString()
           }));
         } else {
           logger.info('🔍 DRY RUN MODE - No actual deployment');
-          logger.info(`   Stack: ${stackName}`);
-          logger.info(`   Changes: ${cdkDiff.changes.added} added, ${cdkDiff.changes.modified} modified, ${cdkDiff.changes.removed} removed`);
+          logger.info(`   Stacks: ${stackDisplayName}`);
+          logger.info(`   Total changes: ${diffSummary.totals.added} added, ${diffSummary.totals.modified} modified, ${diffSummary.totals.removed} removed`);
 
-          if (cdkDiff.hasChanges) {
-            logger.info('\n--- Infrastructure Changes ---');
-
-            if (Object.keys(cdkDiff.resources.added).length > 0) {
-              logger.info('\nResources to be created:');
-              Object.keys(cdkDiff.resources.added).forEach(resourceName => {
-                const resource = cdkDiff.resources.added[resourceName];
-                logger.info(`  + ${resourceName} (${resource.type})`);
-              });
-            }
-
-            if (Object.keys(cdkDiff.resources.modified).length > 0) {
-              logger.info('\nResources to be modified:');
-              Object.keys(cdkDiff.resources.modified).forEach(resourceName => {
-                const resource = cdkDiff.resources.modified[resourceName];
-                logger.info(`  ~ ${resourceName} (${resource.type})`);
-              });
-            }
-
-            if (Object.keys(cdkDiff.resources.removed).length > 0) {
-              logger.info('\nResources to be removed:');
-              Object.keys(cdkDiff.resources.removed).forEach(resourceName => {
-                const resource = cdkDiff.resources.removed[resourceName];
-                logger.info(`  - ${resourceName} (${resource.type})`);
-              });
-            }
-          } else {
+          if (diffSummary.stacks.length === 0) {
             logger.info('   No infrastructure changes detected');
+          } else {
+            logger.info('\n--- Infrastructure Changes ---');
+            logDiffDetails(logger, cdkDiff);
           }
         }
         process.exit(0);
       }
 
       // Check if there are changes to deploy
-      if (!cdkDiff.hasChanges && !options.force) {
+      if (!diffSummary.hasChanges && !options.force) {
         if (opts.ci) {
           console.log(JSON.stringify({
             level: 'info',
             message: 'No changes to deploy',
-            stackName: stackName,
+            stackNames,
             timestamp: new Date().toISOString()
           }));
         } else {
           logger.info('ℹ️  No changes to deploy');
-          logger.info(`   Stack: ${stackName}`);
+          logger.info(`   Stacks: ${stackDisplayName}`);
           logger.info('   Use --force to deploy anyway');
         }
         process.exit(0);
@@ -881,16 +936,16 @@ program
         console.log(JSON.stringify({
           level: 'info',
           message: 'Starting deployment',
-          stackName: stackName,
+          stackNames,
           command: cdkCommand,
-          changes: cdkDiff.changes,
+          diffSummary,
           timestamp: new Date().toISOString()
         }));
       } else {
         logger.info('🚀 Starting deployment');
-        logger.info(`   Stack: ${stackName}`);
+        logger.info(`   Stacks: ${stackDisplayName}`);
         logger.info(`   Command: ${cdkCommand}`);
-        logger.info(`   Changes: ${cdkDiff.changes.added} added, ${cdkDiff.changes.modified} modified, ${cdkDiff.changes.removed} removed`);
+        logger.info(`   Total changes: ${diffSummary.totals.added} added, ${diffSummary.totals.modified} modified, ${diffSummary.totals.removed} removed`);
       }
 
       execSync(cdkCommand, {
@@ -902,12 +957,12 @@ program
         console.log(JSON.stringify({
           level: 'info',
           message: 'Deployment completed successfully',
-          stackName: stackName,
+          stackNames,
           timestamp: new Date().toISOString()
         }));
       } else {
         logger.info('✅ Deployment completed successfully');
-        logger.info(`   Stack: ${stackName}`);
+        logger.info(`   Stacks: ${stackDisplayName}`);
       }
 
       process.exit(0);
@@ -1027,69 +1082,47 @@ program
       }
 
       const cdkDiff = result.data.cdkDiff;
+      const diffSummary = normalizeDiffMap(cdkDiff);
       const stackName = `${result.data.resolvedManifest.service}-stack`;
+      const stackNames = diffSummary.stacks.map(stack => stack.stackName);
+      const stackDisplayName = stackNames.length > 0 ? stackNames.join(', ') : stackName;
 
       if (options.dryRun) {
         if (opts.ci) {
           console.log(JSON.stringify({
             level: 'info',
             message: 'Dry run completed',
-            stackName: stackName,
-            changes: cdkDiff.changes,
-            hasChanges: cdkDiff.hasChanges,
-            resources: cdkDiff.resources,
+            stackNames,
+            diffSummary,
             timestamp: new Date().toISOString()
           }));
         } else {
           logger.info('🔍 DRY RUN MODE - No actual deployment');
-          logger.info(`   Stack: ${stackName}`);
-          logger.info(`   Changes: ${cdkDiff.changes.added} added, ${cdkDiff.changes.modified} modified, ${cdkDiff.changes.removed} removed`);
+          logger.info(`   Stacks: ${stackDisplayName}`);
+          logger.info(`   Total changes: ${diffSummary.totals.added} added, ${diffSummary.totals.modified} modified, ${diffSummary.totals.removed} removed`);
 
-          if (cdkDiff.hasChanges) {
-            logger.info('\n--- Infrastructure Changes ---');
-
-            if (Object.keys(cdkDiff.resources.added).length > 0) {
-              logger.info('\nResources to be created:');
-              Object.keys(cdkDiff.resources.added).forEach(resourceName => {
-                const resource = cdkDiff.resources.added[resourceName];
-                logger.info(`  + ${resourceName} (${resource.type})`);
-              });
-            }
-
-            if (Object.keys(cdkDiff.resources.modified).length > 0) {
-              logger.info('\nResources to be modified:');
-              Object.keys(cdkDiff.resources.modified).forEach(resourceName => {
-                const resource = cdkDiff.resources.modified[resourceName];
-                logger.info(`  ~ ${resourceName} (${resource.type})`);
-              });
-            }
-
-            if (Object.keys(cdkDiff.resources.removed).length > 0) {
-              logger.info('\nResources to be removed:');
-              Object.keys(cdkDiff.resources.removed).forEach(resourceName => {
-                const resource = cdkDiff.resources.removed[resourceName];
-                logger.info(`  - ${resourceName} (${resource.type})`);
-              });
-            }
-          } else {
+          if (diffSummary.stacks.length === 0) {
             logger.info('   No infrastructure changes detected');
+          } else {
+            logger.info('\n--- Infrastructure Changes ---');
+            logDiffDetails(logger, cdkDiff);
           }
         }
         process.exit(0);
       }
 
       // Check if there are changes to deploy
-      if (!cdkDiff.hasChanges && !options.force) {
+      if (!diffSummary.hasChanges && !options.force) {
         if (opts.ci) {
           console.log(JSON.stringify({
             level: 'info',
             message: 'No changes to deploy',
-            stackName: stackName,
+            stackNames,
             timestamp: new Date().toISOString()
           }));
         } else {
           logger.info('ℹ️  No changes to deploy');
-          logger.info(`   Stack: ${stackName}`);
+          logger.info(`   Stacks: ${stackDisplayName}`);
           logger.info('   Use --force to deploy anyway');
         }
         process.exit(0);
@@ -1099,10 +1132,27 @@ program
       logger.info('🔧 Using real CDK synthesis...');
 
       const synthesisResult = result.data.synthesisResult;
+      const synthesizedStacks = synthesisResult.synthesizedStacks || (synthesisResult.synthesizedStack ? [synthesisResult.synthesizedStack] : []);
+      const synthesizedStackNames = synthesizedStacks.map(stack => stack.stackName);
+      const resourcesByStack = synthesizedStacks.reduce((acc, stack) => {
+        acc[stack.stackName] = {
+          resourceCount: Object.keys(stack.template.Resources || {}).length
+        };
+        return acc;
+      }, {});
 
       logger.info(`✅ CDK synthesis completed`);
-      logger.info(`   Stack: ${synthesisResult.synthesizedStack.stackName}`);
-      logger.info(`   Resources: ${Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length}`);
+      if (synthesizedStackNames.length > 0) {
+        logger.info(`   Stacks synthesized: ${synthesizedStackNames.join(', ')}`);
+        synthesizedStacks.forEach(stack => {
+          logger.info(`   Resources (${stack.stackName}): ${Object.keys(stack.template.Resources || {}).length}`);
+        });
+      } else if (synthesisResult.synthesizedStack) {
+        logger.info(`   Stack: ${synthesisResult.synthesizedStack.stackName}`);
+        logger.info(`   Resources: ${Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length}`);
+      } else {
+        logger.info('   No synthesized stack details available');
+      }
 
       // For now, we'll use CDK CLI for actual deployment
       // TODO: Implement real CDK deployment using AWS SDK
@@ -1116,18 +1166,22 @@ program
         console.log(JSON.stringify({
           level: 'info',
           message: 'Starting deployment with ResolverEngine',
-          stackName: stackName,
+          stackNames,
           command: cdkCommand,
-          changes: cdkDiff.changes,
-          resources: Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length,
+          diffSummary,
+          resourcesByStack,
           timestamp: new Date().toISOString()
         }));
       } else {
         logger.info('🚀 Starting deployment with ResolverEngine');
-        logger.info(`   Stack: ${stackName}`);
+        logger.info(`   Stacks: ${stackDisplayName}`);
         logger.info(`   Command: ${cdkCommand}`);
-        logger.info(`   Changes: ${cdkDiff.changes.added} added, ${cdkDiff.changes.modified} modified, ${cdkDiff.changes.removed} removed`);
-        logger.info(`   Resources: ${Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length}`);
+        logger.info(`   Total changes: ${diffSummary.totals.added} added, ${diffSummary.totals.modified} modified, ${diffSummary.totals.removed} removed`);
+        if (synthesizedStackNames.length > 0) {
+          synthesizedStacks.forEach(stack => {
+            logger.info(`   Resources (${stack.stackName}): ${Object.keys(stack.template.Resources || {}).length}`);
+          });
+        }
       }
 
       execSync(cdkCommand, {
@@ -1139,14 +1193,19 @@ program
         console.log(JSON.stringify({
           level: 'info',
           message: 'Deployment completed successfully with real CDK synthesis',
-          stackName: stackName,
-          resources: Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length,
+          stackNames,
+          diffSummary,
+          resourcesByStack,
           timestamp: new Date().toISOString()
         }));
       } else {
         logger.info('✅ Deployment completed successfully with real CDK synthesis');
-        logger.info(`   Stack: ${stackName}`);
-        logger.info(`   Resources: ${Object.keys(synthesisResult.synthesizedStack.template.Resources || {}).length}`);
+        logger.info(`   Stacks: ${stackDisplayName}`);
+        if (synthesizedStackNames.length > 0) {
+          synthesizedStacks.forEach(stack => {
+            logger.info(`   Resources (${stack.stackName}): ${Object.keys(stack.template.Resources || {}).length}`);
+          });
+        }
       }
 
       process.exit(0);

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -16,8 +16,9 @@ export interface PlanResult {
     resolvedManifest: any;
     warnings: string[];
     synthesisResult?: any;
-    cdkDiff?: any;
+    cdkDiff?: Record<string, any>;
     cloudFormationTemplate?: any;
+    cloudFormationTemplates?: Record<string, any>;
   };
   error?: string;
 }
@@ -58,6 +59,12 @@ export class PlanCommand {
       // Perform basic CDK synthesis (simplified for now)
       this.dependencies.logger.info('Synthesizing infrastructure components...');
       const synthesisResult = await this.performBasicCdkSynthesis(validationResult.resolvedManifest);
+
+      const templatesByStackName = synthesisResult.templatesByStackName || {};
+      const firstTemplateKey = Object.keys(templatesByStackName)[0];
+      const primaryTemplate = firstTemplateKey
+        ? templatesByStackName[firstTemplateKey]
+        : synthesisResult.template;
 
       // Perform CDK diff analysis
       this.dependencies.logger.info('Analyzing infrastructure changes...');
@@ -124,7 +131,8 @@ export class PlanCommand {
           warnings: validationResult.warnings || [],
           synthesisResult: synthesisResult,
           cdkDiff: cdkDiff,
-          cloudFormationTemplate: synthesisResult.app.synth().stacks[0].template
+          cloudFormationTemplate: primaryTemplate,
+          cloudFormationTemplates: templatesByStackName
         }
       };
 
@@ -172,17 +180,28 @@ export class PlanCommand {
       }
 
       // Synthesize the app
-      const synthesizedStacks = app.synth().stacks;
-      const synthesizedStack = synthesizedStacks[0];
+      const assembly = app.synth();
+      const synthesizedStacks = assembly.stacks;
 
-      this.dependencies.logger.info(`Synthesized stack: ${synthesizedStack.stackName}`);
-      this.dependencies.logger.debug(`Resources: ${Object.keys(synthesizedStack.template.Resources || {}).length}`);
+      const templatesByStackName = synthesizedStacks.reduce((acc: Record<string, any>, current) => {
+        acc[current.stackName] = current.template;
+        return acc;
+      }, {} as Record<string, any>);
+
+      const primarySynthesizedStack = synthesizedStacks[0];
+
+      synthesizedStacks.forEach(synthesizedStack => {
+        this.dependencies.logger.info(`Synthesized stack: ${synthesizedStack.stackName}`);
+        this.dependencies.logger.debug(`Resources: ${Object.keys(synthesizedStack.template.Resources || {}).length}`);
+      });
 
       return {
         app,
         stacks: [stack],
-        synthesizedStack,
-        template: synthesizedStack.template
+        synthesizedStacks,
+        synthesizedStack: primarySynthesizedStack,
+        template: primarySynthesizedStack?.template,
+        templatesByStackName
       };
 
     } catch (error) {
@@ -437,35 +456,37 @@ export class PlanCommand {
     try {
       this.dependencies.logger.debug('Starting CDK diff analysis');
 
-      // Synthesize the CDK app to get CloudFormation templates
-      const synthesizedStacks = synthesisResult.app.synth().stacks;
-      const stack = synthesizedStacks[0];
-      const stackName = stack.stackName;
-      const newTemplate = stack.template;
+      const synthesizedStacks = synthesisResult.synthesizedStacks || synthesisResult.app.synth().stacks;
+      const diffByStack: Record<string, any> = {};
 
-      this.dependencies.logger.debug(`Analyzing stack: ${stackName}`);
+      for (const stack of synthesizedStacks) {
+        const stackName = stack.stackName;
+        const newTemplate = stack.template;
 
-      // Check if stack exists in AWS
-      const existingTemplate = await this.getExistingStackTemplate(stackName);
+        this.dependencies.logger.debug(`Analyzing stack: ${stackName}`);
 
-      if (!existingTemplate) {
-        // New stack - all resources will be added
-        this.dependencies.logger.info('New stack detected - all resources will be created');
-        return this.analyzeNewStack(newTemplate, stackName);
-      } else {
-        // Existing stack - compare templates
-        this.dependencies.logger.info('Existing stack detected - comparing templates');
-        return this.compareTemplates(existingTemplate, newTemplate, stackName);
+        const existingTemplate = await this.getExistingStackTemplate(stackName);
+
+        if (!existingTemplate) {
+          this.dependencies.logger.info(`New stack detected - all resources will be created (${stackName})`);
+          diffByStack[stackName] = this.analyzeNewStack(newTemplate, stackName);
+        } else {
+          this.dependencies.logger.info(`Existing stack detected - comparing templates (${stackName})`);
+          diffByStack[stackName] = this.compareTemplates(existingTemplate, newTemplate, stackName);
+        }
       }
+
+      return diffByStack;
 
     } catch (error) {
       this.dependencies.logger.warn('CDK diff analysis failed, showing new stack analysis only');
       this.dependencies.logger.debug('Diff error:', error);
 
-      // Fallback to new stack analysis
-      const synthesizedStacks = synthesisResult.app.synth().stacks;
-      const stack = synthesizedStacks[0];
-      return this.analyzeNewStack(stack.template, stack.stackName);
+      const synthesizedStacks = synthesisResult.synthesizedStacks || synthesisResult.app.synth().stacks;
+      return synthesizedStacks.reduce((acc: Record<string, any>, stack: any) => {
+        acc[stack.stackName] = this.analyzeNewStack(stack.template, stack.stackName);
+        return acc;
+      }, {} as Record<string, any>);
     }
   }
 

--- a/tests/unit/services/plan-output-formatter.test.ts
+++ b/tests/unit/services/plan-output-formatter.test.ts
@@ -1,0 +1,89 @@
+import { PlanOutputFormatter } from '../../../src/services/plan-output-formatter';
+
+describe('PlanOutputFormatter multi-stack diff support', () => {
+  const logger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    success: jest.fn()
+  } as any;
+
+  const formatter = new PlanOutputFormatter({ logger });
+
+  const baseSynthesisResult = {
+    resolvedManifest: {
+      components: [
+        { name: 'api', type: 'lambda-api', config: {} },
+        { name: 'database', type: 'rds-postgres', config: {} }
+      ],
+      binds: []
+    },
+    components: [],
+    bindings: [],
+    stacks: [],
+    patchesApplied: false,
+    synthesisTime: 125
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('aggregates diff summaries across multiple stacks', () => {
+    const cdkDiff = {
+      'service-stack-primary': {
+        resources: {
+          added: {
+            ApiResource: { type: 'AWS::ApiGateway::RestApi', properties: {} }
+          },
+          modified: {},
+          removed: {}
+        },
+        changes: { added: 1, modified: 0, removed: 0, total: 1 },
+        hasChanges: true,
+        stackName: 'service-stack-primary'
+      },
+      'service-stack-analytics': {
+        resources: {
+          added: {},
+          modified: {
+            WorkerLambda: {
+              type: 'AWS::Lambda::Function',
+              existing: {},
+              updated: {}
+            }
+          },
+          removed: {
+            LegacyTable: { type: 'AWS::DynamoDB::Table', properties: {} }
+          }
+        },
+        changes: { added: 0, modified: 1, removed: 1, total: 2 },
+        hasChanges: true,
+        stackName: 'service-stack-analytics',
+        security: {
+          warnings: ['Ensure encryption at rest for DynamoDB tables']
+        }
+      }
+    };
+
+    const output = formatter.formatPlanOutput({
+      synthesisResult: baseSynthesisResult,
+      cdkDiff,
+      environment: 'dev',
+      complianceFramework: 'commercial'
+    });
+
+    expect(output.structuredData.changes.totals).toEqual({
+      added: 1,
+      modified: 1,
+      removed: 1,
+      total: 3
+    });
+
+    expect(output.structuredData.changes.stacks).toHaveLength(2);
+    expect(output.structuredData.changes.hasChanges).toBe(true);
+    expect(output.warnings).toContain('Ensure encryption at rest for DynamoDB tables');
+    expect(output.userFriendlySummary).toContain('Stack: service-stack-primary');
+    expect(output.userFriendlySummary).toContain('Stack: service-stack-analytics');
+  });
+});
+

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -12,6 +12,7 @@
   },
   "include": [
     "packages/*/src/**/*",
-    "packages/*/tests/**/*"
+    "packages/*/tests/**/*",
+    "tests/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- return synthesized stack templates for every stack and diff each stack individually in the plan command
- teach the plan output formatter and CLI helpers to aggregate CDK diffs across multiple stacks
- add a unit test exercising PlanOutputFormatter with multi-stack diff input and include repository tests in tsconfig.jest.json

## Testing
- npm run test:unit *(fails: jest not found because workspace dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9949f1114833397d3bc32bea8b694