### PR TITLE
Use AWS SDK for stack template retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/json-schema": "^7.0.15",
     "@types/mustache": "^4.2.6",
     "@types/node": "^24.3.1",
+    "@aws-sdk/client-cloudformation": "^3.637.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "aws-cdk-lib": "^2.214.0",

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -1,8 +1,9 @@
 import { Logger } from '../utils/logger';
 import { ValidationOrchestrator } from '../services/validation-orchestrator';
 import { FileDiscovery } from './utils/file-discovery';
+import { CloudFormationClient, GetTemplateCommand } from '@aws-sdk/client-cloudformation';
 import * as cdk from 'aws-cdk-lib';
-import { execSync } from 'child_process';
+import { load as loadYaml } from 'js-yaml';
 
 export interface PlanOptions {
   file?: string;
@@ -29,7 +30,11 @@ interface PlanDependencies {
 }
 
 export class PlanCommand {
-  constructor(private dependencies: PlanDependencies) { }
+  private cloudFormationClient: CloudFormationClient;
+
+  constructor(private dependencies: PlanDependencies) {
+    this.cloudFormationClient = new CloudFormationClient({});
+  }
 
   async execute(options: PlanOptions): Promise<PlanResult> {
     this.dependencies.logger.debug('Starting plan command', options);
@@ -474,34 +479,89 @@ export class PlanCommand {
    */
   private async getExistingStackTemplate(stackName: string): Promise<any | null> {
     try {
-      // Check if AWS credentials are available
-      if (!process.env.AWS_ACCESS_KEY_ID && !process.env.AWS_PROFILE) {
-        this.dependencies.logger.debug('No AWS credentials found - treating as new stack');
+      const response = await this.cloudFormationClient.send(new GetTemplateCommand({
+        StackName: stackName
+      }));
+
+      const templateBody = response.TemplateBody;
+      if (!templateBody) {
+        this.dependencies.logger.debug(`No template body returned for stack ${stackName}`);
         return null;
       }
 
-      // Use AWS CLI to get stack template
-      const command = `aws cloudformation get-template --stack-name ${stackName} --query 'TemplateBody' --output text`;
-
       try {
-        const result = execSync(command, {
-          encoding: 'utf8',
-          stdio: 'pipe',
-          timeout: 10000 // 10 second timeout
-        });
-
-        return JSON.parse(result.trim());
-      } catch (error: any) {
-        if (error.message.includes('does not exist') || error.message.includes('Stack with id') && error.message.includes('does not exist')) {
-          this.dependencies.logger.debug(`Stack ${stackName} does not exist in AWS`);
+        return JSON.parse(templateBody);
+      } catch (jsonError) {
+        try {
+          const yamlTemplate = loadYaml(templateBody);
+          return yamlTemplate === undefined ? null : yamlTemplate;
+        } catch (yamlError) {
+          this.dependencies.logger.debug('Failed to parse stack template body as JSON or YAML', {
+            jsonError,
+            yamlError
+          });
           return null;
         }
-        throw error;
       }
-    } catch (error) {
+    } catch (error: any) {
+      if (this.isStackDoesNotExistError(error)) {
+        this.dependencies.logger.debug(`Stack ${stackName} does not exist in AWS`);
+        return null;
+      }
+
+      if (this.isAccessOrCredentialError(error)) {
+        const message = error?.message ?? 'Access denied retrieving stack template';
+        this.dependencies.logger.warn(`Unable to retrieve existing stack template for ${stackName}: ${message}`);
+        this.dependencies.logger.debug('Access error details:', error);
+        return null;
+      }
+
       this.dependencies.logger.debug('Failed to get existing stack template:', error);
       return null;
     }
+  }
+
+  private isStackDoesNotExistError(error: any): boolean {
+    const message = (error?.message ?? '').toString().toLowerCase();
+    return message.includes('does not exist');
+  }
+
+  private isAccessOrCredentialError(error: any): boolean {
+    const code = (error?.name ?? error?.code ?? '').toString().toLowerCase();
+    const statusCode = error?.$metadata?.httpStatusCode;
+    if (statusCode === 403) {
+      return true;
+    }
+
+    const accessErrorCodes = [
+      'accessdenied',
+      'accessdeniedexception',
+      'unrecognizedclient',
+      'unrecognizedclientexception',
+      'invalidclienttokenid',
+      'expiredtoken',
+      'expiredtokenexception',
+      'credentialsprovidererror'
+    ];
+
+    if (code && accessErrorCodes.some(errorCode => code.includes(errorCode))) {
+      return true;
+    }
+
+    const message = (error?.message ?? '').toString().toLowerCase();
+    const accessKeywords = [
+      'not authorized',
+      'access denied',
+      'unable to locate credentials',
+      'missing credentials',
+      'could not load credentials',
+      'unrecognized client',
+      'invalid client token',
+      'security token included in the request is expired',
+      'expired token'
+    ];
+
+    return accessKeywords.some(keyword => message.includes(keyword));
   }
 
   /**


### PR DESCRIPTION
## Summary
- replace the AWS CLI execSync call with the AWS SDK v3 CloudFormation client and parse template bodies with JSON/YAML handling
- add handling for missing stacks and credential/access warnings while keeping plan analysis logging intact
- add the AWS SDK CloudFormation client dependency for the CLI

## Testing
- npm test *(fails: jest: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a08b2f508333832c9ce1b03dc68a