### PR TITLE
Optimize resolver binder validation lookup

### DIFF
--- a/packages/core/src/resolver/binder-registry.spec.ts
+++ b/packages/core/src/resolver/binder-registry.spec.ts
@@ -1,0 +1,29 @@
+import { ResolverBinderRegistry } from './binder-registry';
+
+describe('ResolverBinderRegistry', () => {
+  let registry: ResolverBinderRegistry;
+
+  beforeEach(() => {
+    registry = new ResolverBinderRegistry();
+  });
+
+  it('approves supported bindings using the precomputed lookup', () => {
+    expect(registry.validateBinding('lambda-api', 'queue:sqs')).toEqual({ valid: true });
+  });
+
+  it('suggests available targets for a known source type', () => {
+    expect(registry.validateBinding('lambda-api', 'queue:sns')).toEqual({
+      valid: false,
+      reason: "No binding strategy for 'lambda-api' -> 'queue:sns'",
+      suggestion: "Available targets for 'lambda-api': queue:sqs, db:postgres, bucket:s3"
+    });
+  });
+
+  it('lists supported source types when none are available for a given source', () => {
+    expect(registry.validateBinding('step-function', 'queue:sqs')).toEqual({
+      valid: false,
+      reason: "No binding strategies available for source type 'step-function'",
+      suggestion: 'Supported source types: lambda-api, lambda-worker'
+    });
+  });
+});

--- a/packages/core/src/resolver/binder-registry.ts
+++ b/packages/core/src/resolver/binder-registry.ts
@@ -5,6 +5,65 @@
 
 import { LambdaToSqsBinderStrategy, LambdaToRdsBinderStrategy, LambdaToS3BucketBinderStrategy } from './binders/concrete-binders';
 
+type BindingMatrixEntry = {
+  readonly sourceType: string;
+  readonly targetCapability: string;
+  readonly description: string;
+  readonly supported: boolean;
+};
+
+const BINDING_MATRIX: ReadonlyArray<BindingMatrixEntry> = Object.freeze([
+  { sourceType: 'lambda-api', targetCapability: 'queue:sqs', description: 'Lambda -> SQS', supported: true },
+  { sourceType: 'lambda-worker', targetCapability: 'queue:sqs', description: 'Lambda worker -> SQS', supported: true },
+  { sourceType: 'lambda-api', targetCapability: 'db:postgres', description: 'Lambda -> Postgres', supported: true },
+  { sourceType: 'lambda-worker', targetCapability: 'db:postgres', description: 'Lambda worker -> Postgres', supported: true },
+  { sourceType: 'lambda-api', targetCapability: 'bucket:s3', description: 'Lambda -> S3', supported: true },
+  { sourceType: 'lambda-worker', targetCapability: 'bucket:s3', description: 'Lambda worker -> S3', supported: true }
+]);
+
+interface SourceBindingIndex {
+  readonly supportedTargets: ReadonlyArray<string>;
+  readonly supportedTargetSet: ReadonlySet<string>;
+}
+
+const SOURCE_BINDING_INDEX: ReadonlyMap<string, SourceBindingIndex> = (() => {
+  const mutableIndex = new Map<string, { targets: string[]; targetSet: Set<string> }>();
+
+  for (const entry of BINDING_MATRIX) {
+    if (!entry.supported) {
+      continue;
+    }
+
+    const existing = mutableIndex.get(entry.sourceType);
+    if (existing) {
+      if (!existing.targetSet.has(entry.targetCapability)) {
+        existing.targetSet.add(entry.targetCapability);
+        existing.targets.push(entry.targetCapability);
+      }
+      continue;
+    }
+
+    mutableIndex.set(entry.sourceType, {
+      targets: [entry.targetCapability],
+      targetSet: new Set([entry.targetCapability])
+    });
+  }
+
+  return new Map(
+    Array.from(mutableIndex.entries(), ([sourceType, meta]) => [
+      sourceType,
+      {
+        supportedTargets: Object.freeze([...meta.targets]),
+        supportedTargetSet: meta.targetSet as ReadonlySet<string>
+      }
+    ])
+  );
+})();
+
+const SUPPORTED_SOURCE_TYPES: ReadonlyArray<string> = Object.freeze([
+  ...SOURCE_BINDING_INDEX.keys()
+]);
+
 /**
  * Deprecated Resolver Binder Registry shim
  */
@@ -23,20 +82,8 @@ export class ResolverBinderRegistry {
   /**
    * Legacy binding matrix retained for docs/tests; static suggestions only
    */
-  getBindingMatrix(): Array<{
-    sourceType: string;
-    targetCapability: string;
-    description: string;
-    supported: boolean;
-  }> {
-    return [
-      { sourceType: 'lambda-api', targetCapability: 'queue:sqs', description: 'Lambda -> SQS', supported: true },
-      { sourceType: 'lambda-worker', targetCapability: 'queue:sqs', description: 'Lambda worker -> SQS', supported: true },
-      { sourceType: 'lambda-api', targetCapability: 'db:postgres', description: 'Lambda -> Postgres', supported: true },
-      { sourceType: 'lambda-worker', targetCapability: 'db:postgres', description: 'Lambda worker -> Postgres', supported: true },
-      { sourceType: 'lambda-api', targetCapability: 'bucket:s3', description: 'Lambda -> S3', supported: true },
-      { sourceType: 'lambda-worker', targetCapability: 'bucket:s3', description: 'Lambda worker -> S3', supported: true }
-    ];
+  getBindingMatrix(): ReadonlyArray<BindingMatrixEntry> {
+    return BINDING_MATRIX;
   }
 
   validateBinding(sourceType: string, targetCapability: string): {
@@ -44,26 +91,24 @@ export class ResolverBinderRegistry {
     reason?: string;
     suggestion?: string;
   } {
-    const availableTargets = this.getBindingMatrix()
-      .filter(binding => binding.sourceType === sourceType && binding.supported)
-      .map(binding => binding.targetCapability);
+    const bindingMeta = SOURCE_BINDING_INDEX.get(sourceType);
 
-    if (availableTargets.includes(targetCapability)) {
+    if (bindingMeta?.supportedTargetSet.has(targetCapability)) {
       return { valid: true };
     }
 
-    if (availableTargets.length === 0) {
+    if (!bindingMeta || bindingMeta.supportedTargets.length === 0) {
       return {
         valid: false,
         reason: `No binding strategies available for source type '${sourceType}'`,
-        suggestion: `Supported source types: ${[...new Set(this.getBindingMatrix().map(b => b.sourceType))].join(', ')}`
+        suggestion: `Supported source types: ${SUPPORTED_SOURCE_TYPES.join(', ')}`
       };
     }
 
     return {
       valid: false,
       reason: `No binding strategy for '${sourceType}' -> '${targetCapability}'`,
-      suggestion: `Available targets for '${sourceType}': ${availableTargets.join(', ')}`
+      suggestion: `Available targets for '${sourceType}': ${bindingMeta.supportedTargets.join(', ')}`
     };
   }
 }


### PR DESCRIPTION
## Summary
- precompute immutable binding metadata for the resolver registry
- use the cached lookup for validation suggestions to avoid repeated scans
- add unit tests that cover success, unknown source, and unsupported target bindings

## Testing
- pnpm --filter @shinobi/core test *(fails: jest executable not available without workspace install)*
- pnpm install --frozen-lockfile *(fails: pnpm-lock.yaml out of date with apps/svc/package.json)*
- pnpm install *(fails: registry returned 403 for tsconfig-paths and ts-node; workspace dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ba0005cc8333874fe79ab157d10e