### PR TITLE
Optimize resource mapper dependency checks

### DIFF
--- a/packages/core/src/migration/__tests__/resource-mapper.spec.ts
+++ b/packages/core/src/migration/__tests__/resource-mapper.spec.ts
@@ -1,0 +1,91 @@
+import { LogLevel, Logger } from '../../core-engine/logger';
+import { CloudFormationResource, StackAnalysisResult } from '../cloudformation-analyzer';
+import { ResourceMapper } from '../resource-mapper';
+
+describe('ResourceMapper dependency optimization', () => {
+  const buildAnalysisResult = (resources: CloudFormationResource[]): StackAnalysisResult => ({
+    stackName: 'TestStack',
+    templatePath: 'template.json',
+    template: {},
+    resources,
+    outputs: {},
+    parameters: {},
+    metadata: {}
+  });
+
+  it('serializes resource properties once per resource when discovering property-based dependencies', async () => {
+    const mapper = new ResourceMapper(new Logger(LogLevel.ERROR));
+    const resources: CloudFormationResource[] = [
+      {
+        logicalId: 'Topic',
+        type: 'AWS::SNS::Topic',
+        properties: {}
+      },
+      {
+        logicalId: 'TopicPolicy',
+        type: 'AWS::SNS::TopicPolicy',
+        properties: {
+          Topics: [{ Ref: 'Topic' }]
+        }
+      },
+      {
+        logicalId: 'Subscription',
+        type: 'AWS::SNS::Subscription',
+        properties: {
+          TopicArn: { Ref: 'Topic' }
+        }
+      }
+    ];
+
+    const stringifySpy = jest.spyOn(JSON, 'stringify');
+
+    await mapper.mapResources(buildAnalysisResult(resources), 'service', 'framework');
+
+    expect(stringifySpy).toHaveBeenCalledTimes(3);
+
+    stringifySpy.mockRestore();
+  });
+
+  it('resets cached dependency metadata between mapResources executions', async () => {
+    const mapper = new ResourceMapper(new Logger(LogLevel.ERROR));
+    const firstResources: CloudFormationResource[] = [
+      {
+        logicalId: 'LegacyPrimary',
+        type: 'AWS::SNS::Topic',
+        properties: {}
+      },
+      {
+        logicalId: 'SharedPolicy',
+        type: 'AWS::SNS::TopicPolicy',
+        properties: {
+          Topics: [{ Ref: 'LegacyPrimary' }]
+        }
+      }
+    ];
+
+    await mapper.mapResources(buildAnalysisResult(firstResources), 'service', 'framework');
+
+    const stringifySpy = jest.spyOn(JSON, 'stringify');
+
+    const secondResources: CloudFormationResource[] = [
+      {
+        logicalId: 'NewPrimary',
+        type: 'AWS::SNS::Topic',
+        properties: {}
+      },
+      {
+        logicalId: 'SharedPolicy',
+        type: 'AWS::SNS::TopicPolicy',
+        properties: {
+          Topics: [{ Ref: 'NewPrimary' }]
+        }
+      }
+    ];
+
+    await mapper.mapResources(buildAnalysisResult(secondResources), 'service', 'framework');
+
+    expect(stringifySpy).toHaveBeenCalledTimes(2);
+
+    stringifySpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- cache serialized resource properties and dependency sets to avoid repeated JSON.stringify work during CloudFormation grouping
- reset caches at the start of each mapping run to prevent stale dependency metadata reuse
- add regression tests validating the caching behaviour and cache reset between runs

## Testing
- pnpm exec nx test core *(fails: Nx CLI not available without installing dependencies; pnpm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ba0005cc8333874fe79ab157d10e