### PR TITLE
docs: expand MCP OpenAPI spec

### DIFF
--- a/docs/api/mcp-openapi.yaml
+++ b/docs/api/mcp-openapi.yaml
@@ -7,11 +7,29 @@ info:
     name: Platform Engineering
     email: platform-engineering@project42.com
 servers:
-  - url: https://mcp.shinobi.platform
-    description: Shinobi MCP server
+  - url: https://mcp.shinobi.platform/api/v1
+    description: Production MCP server
+  - url: http://localhost:4000/api/v1
+    description: Local development server
+security:
+  - bearerAuth: []
+tags:
+  - name: Tools
+    description: MCP tool discovery and invocation
+  - name: Platform
+    description: Platform catalog, capability, and validation APIs
+  - name: Services
+    description: Managed service inventory and runtime insights
+  - name: Generative
+    description: Scaffold generation utilities for new components
+  - name: Admin
+    description: Privileged administration and diagnostics
+  - name: Health
+    description: Anonymous health and readiness checks
 paths:
   /tools:
     get:
+      tags: [Tools]
       summary: List available MCP tools
       description: Get list of all available MCP tools
       responses:
@@ -25,16 +43,14 @@ paths:
                   tools:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        parameters:
-                          type: object
+                      $ref: '#/components/schemas/ToolSummary'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
   /tools/{toolName}:
     post:
+      tags: [Tools]
       summary: Execute MCP tool
       description: Execute a specific MCP tool
       parameters:
@@ -52,6 +68,7 @@ paths:
               properties:
                 arguments:
                   type: object
+                  additionalProperties: {}
       responses:
         "200":
           description: Tool execution result
@@ -59,3 +76,1494 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: {}
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "404":
+          $ref: '#/components/responses/NotFoundError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/components:
+    get:
+      tags: [Platform]
+      summary: List available components
+      description: Lists all available, versioned infrastructure components published by the platform.
+      responses:
+        "200":
+          description: Successful response containing component catalog entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PlatformComponent'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/components/{type}/schema:
+    get:
+      tags: [Platform]
+      summary: Get component schema
+      description: Returns the JSON schema describing configuration for a given component type.
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Component configuration schema.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentSchema'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "404":
+          $ref: '#/components/responses/NotFoundError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/capabilities:
+    get:
+      tags: [Platform]
+      summary: List platform capabilities
+      description: Returns the capability taxonomy supported across managed components.
+      responses:
+        "200":
+          description: Successful response containing capability definitions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CapabilityDefinition'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/bindings:
+    get:
+      tags: [Platform]
+      summary: List binding matrix
+      description: Returns supported binding strategies between components and capabilities.
+      responses:
+        "200":
+          description: Successful response containing binding matrix entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BindingMatrix'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/validate:
+    post:
+      tags: [Platform]
+      summary: Validate service manifest
+      description: Validates a provided service manifest against platform policy and component schemas.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceManifest'
+      responses:
+        "200":
+          description: Validation output.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResult'
+        "400":
+          description: Manifest failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /platform/generate/component:
+    post:
+      tags: [Generative]
+      summary: Generate component scaffolding
+      description: Generates boilerplate code, configuration, and supporting assets for a new component.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComponentGenerationRequest'
+      responses:
+        "200":
+          description: Successfully generated component assets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComponentGenerationResult'
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /services:
+    get:
+      tags: [Services]
+      summary: List managed services
+      description: Lists all services managed by the platform with aggregated component metadata.
+      responses:
+        "200":
+          description: Successful response containing service inventory.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ServiceInfo'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /services/{name}:
+    get:
+      tags: [Services]
+      summary: Get service details
+      description: Provides a consolidated view of a specific service and its managed components.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Detailed service information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceInfo'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "404":
+          $ref: '#/components/responses/NotFoundError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /services/{name}/manifest:
+    get:
+      tags: [Services]
+      summary: Get service manifest
+      description: Returns the current service manifest tracked for the specified service.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Service manifest definition.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceManifest'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "404":
+          $ref: '#/components/responses/NotFoundError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /services/{name}/status:
+    get:
+      tags: [Services]
+      summary: Get live service status
+      description: Returns live infrastructure status, health checks, and alerts for a given service.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Service runtime status snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceStatus'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "404":
+          $ref: '#/components/responses/NotFoundError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /services/{name}/logs:
+    get:
+      tags: [Services]
+      summary: Get service logs
+      description: Streams structured logs correlated across a service's components.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of log entries to return.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+        - name: startTime
+          in: query
+          description: ISO-8601 timestamp to start the log slice from.
+          required: false
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: Collection of structured log entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LogEntry'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /admin/health:
+    get:
+      tags: [Admin]
+      summary: MCP server deep health check
+      description: Performs comprehensive health diagnostics across backing systems.
+      responses:
+        "200":
+          description: Health check completed (healthy or degraded).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "503":
+          description: Health check failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+  /admin/registry/reload:
+    post:
+      tags: [Admin]
+      summary: Reload component registry
+      description: Clears caches and repopulates the component registry from source packages.
+      responses:
+        "200":
+          description: Registry reload executed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryReloadResult'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /admin/audit:
+    get:
+      tags: [Admin]
+      summary: Query platform audit logs
+      description: Retrieves audit log entries filtered by service, component, action, actor, severity, or time range.
+      parameters:
+        - name: service
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: component
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: action
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: actor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: severity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [info, warning, critical]
+        - name: startTime
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: endTime
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Matching audit log entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLogEntry'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /admin/dependencies:
+    get:
+      tags: [Admin]
+      summary: Get dependency graph
+      description: Returns the platform dependency graph with component bindings and critical paths.
+      parameters:
+        - name: component
+          in: query
+          required: false
+          description: Filter graph to services containing the specified component name.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Dependency graph snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DependencyGraph'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /admin/drift:
+    get:
+      tags: [Admin]
+      summary: Detect configuration drift
+      description: Executes drift detection scans across managed services.
+      parameters:
+        - name: service
+          in: query
+          required: false
+          description: Limit drift detection to a single service.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Drift scan results by service.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DriftDetectionResult'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/ServerError'
+  /health:
+    get:
+      security: []
+      tags: [Health]
+      summary: MCP server liveness probe
+      description: Lightweight unauthenticated endpoint for platform health checks.
+      responses:
+        "200":
+          description: Server is reachable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  timestamp:
+                    type: string
+                    format: date-time
+                  service:
+                    type: string
+                    example: mcp-server
+                  version:
+                    type: string
+                  environment:
+                    type: string
+        "503":
+          $ref: '#/components/responses/ServerError'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    UnauthorizedError:
+      description: Authentication token missing or invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFoundError:
+      description: Requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    BadRequestError:
+      description: Request payload failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    ServerError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        status:
+          type: string
+          description: Optional status indicator used by some endpoints.
+        timestamp:
+          type: string
+          format: date-time
+        path:
+          type: string
+        availableEndpoints:
+          type: array
+          items:
+            type: string
+      additionalProperties: true
+    ToolSummary:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolParameter'
+    ToolParameter:
+      type: object
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+        required:
+          type: boolean
+        enum:
+          type: array
+          items:
+            type: string
+        items:
+          type: object
+    PlatformComponent:
+      type: object
+      required: [name, type, version, description, author]
+      properties:
+        name:
+          type: string
+          description: Human-friendly component name.
+        type:
+          type: string
+          description: Canonical component type identifier.
+        version:
+          type: string
+        description:
+          type: string
+        author:
+          type: string
+        keywords:
+          type: array
+          items:
+            type: string
+        supportedFrameworks:
+          type: array
+          items:
+            type: string
+        configSchema:
+          description: Inline configuration schema or reference identifier.
+          oneOf:
+            - type: object
+            - type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+        bindings:
+          type: array
+          items:
+            type: string
+        triggers:
+          type: array
+          items:
+            type: string
+    ComponentSchema:
+      type: object
+      required: [type, title]
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+        required:
+          type: array
+          items:
+            type: string
+        defaults:
+          type: object
+          additionalProperties: {}
+    CapabilityDefinition:
+      type: object
+      required: [name, description, type, fields]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        type:
+          type: string
+          enum: [compute, storage, database, messaging, api, security, monitoring]
+        fields:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/CapabilityField'
+        examples:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+    CapabilityField:
+      type: object
+      required: [type, description, required]
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+        required:
+          type: boolean
+    BindingMatrix:
+      type: object
+      required: [sourceType, targetType, capability, supportedAccess]
+      properties:
+        sourceType:
+          type: string
+        targetType:
+          type: string
+        capability:
+          type: string
+        supportedAccess:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        strategy:
+          type: string
+        constraints:
+          type: object
+          additionalProperties: {}
+    ValidationResult:
+      type: object
+      required: [valid, errors, warnings, suggestions]
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationWarning'
+        suggestions:
+          type: array
+          items:
+            type: string
+    ValidationError:
+      type: object
+      required: [path, message, code, severity]
+      properties:
+        path:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+        severity:
+          type: string
+          enum: [error, warning]
+    ValidationWarning:
+      type: object
+      required: [path, message, code]
+      properties:
+        path:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+        suggestion:
+          type: string
+    ServiceManifest:
+      type: object
+      required: [service, owner, components]
+      properties:
+        service:
+          type: string
+          pattern: '^[a-z0-9-]+$'
+        owner:
+          type: string
+        complianceFramework:
+          type: string
+          enum: [commercial, fedramp-moderate, fedramp-high]
+          default: commercial
+        runtime:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        environments:
+          $ref: '#/components/schemas/EnvironmentConfiguration'
+        components:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/Component'
+        extensions:
+          $ref: '#/components/schemas/Extensions'
+        metadata:
+          type: object
+          properties:
+            lastModified:
+              type: string
+              format: date-time
+            modifiedBy:
+              type: string
+            gitHash:
+              type: string
+            gitBranch:
+              type: string
+    EnvironmentConfiguration:
+      type: object
+      description: Configuration defaults for different environments.
+      properties:
+        '$ref':
+          type: string
+          description: Relative path to an external configuration file.
+      additionalProperties:
+        type: object
+        properties:
+          '$ref':
+            type: string
+          defaults:
+            type: object
+            additionalProperties: {}
+    Component:
+      type: object
+      required: [name, type]
+      properties:
+        name:
+          type: string
+          pattern: '^[a-z0-9-]+$'
+        type:
+          type: string
+        config:
+          type: object
+          additionalProperties: {}
+        binds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Binding'
+        triggers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trigger'
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        overrides:
+          type: object
+          additionalProperties: {}
+        policy:
+          type: object
+          additionalProperties: {}
+    Binding:
+      type: object
+      required: [capability, access]
+      properties:
+        to:
+          type: string
+        select:
+          $ref: '#/components/schemas/Selector'
+        capability:
+          type: string
+        access:
+          type: string
+          enum: [read, write, readwrite, admin, consume, publish]
+        env:
+          type: object
+          additionalProperties: {}
+        options:
+          type: object
+          additionalProperties: {}
+    Trigger:
+      type: object
+      required: [event, target]
+      properties:
+        event:
+          type: string
+        target:
+          type: string
+    Selector:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+        withLabels:
+          type: object
+          additionalProperties:
+            type: string
+    Extensions:
+      type: object
+      properties:
+        patches:
+          type: array
+          items:
+            $ref: '#/components/schemas/Patch'
+    Patch:
+      type: object
+      required: [name, justification, owner, expiresOn]
+      properties:
+        name:
+          type: string
+        justification:
+          type: string
+          minLength: 20
+        owner:
+          type: string
+        expiresOn:
+          type: string
+          format: date
+    ServiceInfo:
+      type: object
+      required:
+        - name
+        - owner
+        - complianceFramework
+        - environment
+        - region
+        - status
+        - deployedAt
+        - lastUpdated
+        - version
+        - components
+      properties:
+        name:
+          type: string
+        owner:
+          type: string
+        complianceFramework:
+          type: string
+        environment:
+          type: string
+        region:
+          type: string
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy, unknown]
+        deployedAt:
+          type: string
+          format: date-time
+        lastUpdated:
+          type: string
+          format: date-time
+        version:
+          type: string
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComponentInfo'
+    ComponentInfo:
+      type: object
+      required: [name, type, status, resourceIds, bindings, metrics]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy, unknown]
+        resourceIds:
+          type: array
+          items:
+            type: string
+        capabilities:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: {}
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/BindingInfo'
+        metrics:
+          $ref: '#/components/schemas/ComponentMetrics'
+    BindingInfo:
+      type: object
+      required: [target, capability, access, status]
+      properties:
+        target:
+          type: string
+        capability:
+          type: string
+        access:
+          type: string
+        status:
+          type: string
+          enum: [active, inactive, error]
+    ComponentMetrics:
+      type: object
+      properties:
+        cpu:
+          $ref: '#/components/schemas/MetricRange'
+        memory:
+          $ref: '#/components/schemas/MetricRange'
+        requests:
+          $ref: '#/components/schemas/RequestMetrics'
+        connections:
+          $ref: '#/components/schemas/ConnectionMetrics'
+    MetricRange:
+      type: object
+      properties:
+        average:
+          type: number
+        peak:
+          type: number
+        unit:
+          type: string
+    RequestMetrics:
+      type: object
+      properties:
+        total:
+          type: integer
+        errorRate:
+          type: number
+          format: float
+        averageLatency:
+          type: number
+        unit:
+          type: string
+    ConnectionMetrics:
+      type: object
+      properties:
+        active:
+          type: integer
+        peak:
+          type: integer
+    ServiceStatus:
+      type: object
+      required: [service, environment, overallStatus, lastChecked, components]
+      properties:
+        service:
+          type: string
+        environment:
+          type: string
+        overallStatus:
+          type: string
+          enum: [healthy, degraded, unhealthy, unknown]
+        lastChecked:
+          type: string
+          format: date-time
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceComponentStatus'
+        infrastructure:
+          type: object
+          properties:
+            vpc:
+              type: object
+              properties:
+                vpcId:
+                  type: string
+                status:
+                  type: string
+                subnets:
+                  type: integer
+            loadBalancers:
+              type: array
+              items:
+                type: object
+                properties:
+                  arn:
+                    type: string
+                  dnsName:
+                    type: string
+                  status:
+                    type: string
+                  targets:
+                    type: integer
+    ServiceComponentStatus:
+      type: object
+      required: [name, type, status, awsResources, healthChecks, alerts]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy, unknown]
+        awsResources:
+          type: array
+          items:
+            $ref: '#/components/schemas/AwsResourceStatus'
+        healthChecks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceHealthCheck'
+        alerts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
+    AwsResourceStatus:
+      type: object
+      required: [resourceType, resourceId, status, region, lastUpdated]
+      properties:
+        resourceType:
+          type: string
+        resourceId:
+          type: string
+        status:
+          type: string
+        region:
+          type: string
+        lastUpdated:
+          type: string
+          format: date-time
+        configuration:
+          type: object
+          additionalProperties: {}
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+    ServiceHealthCheck:
+      type: object
+      required: [name, status, lastChecked, message]
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum: [passing, warning, critical]
+        lastChecked:
+          type: string
+          format: date-time
+        message:
+          type: string
+        endpoint:
+          type: string
+          format: uri
+    Alert:
+      type: object
+      required: [id, severity, title, description, createdAt]
+      properties:
+        id:
+          type: string
+        severity:
+          type: string
+          enum: [info, warning, critical]
+        title:
+          type: string
+        description:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        acknowledgedAt:
+          type: string
+          format: date-time
+        resolvedAt:
+          type: string
+          format: date-time
+    LogEntry:
+      type: object
+      required: [timestamp, level, component, message]
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        level:
+          type: string
+          enum: [DEBUG, INFO, WARN, ERROR]
+        component:
+          type: string
+        message:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+        traceId:
+          type: string
+        spanId:
+          type: string
+        correlationId:
+          type: string
+    ComponentGenerationRequest:
+      type: object
+      required:
+        - componentName
+        - componentType
+        - description
+        - awsService
+        - capabilities
+        - bindings
+        - triggers
+      properties:
+        componentName:
+          type: string
+          pattern: '^[a-z][a-z0-9-]*$'
+        componentType:
+          type: string
+        description:
+          type: string
+        awsService:
+          type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+        bindings:
+          type: array
+          items:
+            type: string
+        triggers:
+          type: array
+          items:
+            type: string
+        complianceFramework:
+          type: string
+          enum: [commercial, fedramp-moderate, fedramp-high]
+        templateOptions:
+          type: object
+          properties:
+            includeTests:
+              type: boolean
+            includeDocumentation:
+              type: boolean
+            includeBinders:
+              type: boolean
+            includeCreator:
+              type: boolean
+    ComponentGenerationResult:
+      type: object
+      required: [componentName, files, dependencies, instructions, summary]
+      properties:
+        componentName:
+          type: string
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeneratedFile'
+        dependencies:
+          type: array
+          items:
+            type: string
+        instructions:
+          type: array
+          items:
+            type: string
+        summary:
+          type: string
+    GeneratedFile:
+      type: object
+      required: [path, content, type, description]
+      properties:
+        path:
+          type: string
+        content:
+          type: string
+        type:
+          type: string
+          enum: [typescript, json, yaml, markdown, dockerfile]
+        description:
+          type: string
+    HealthStatus:
+      type: object
+      required: [status, timestamp, version, environment, checks, summary]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        timestamp:
+          type: string
+          format: date-time
+        version:
+          type: string
+        environment:
+          type: string
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminHealthCheck'
+        summary:
+          type: object
+          properties:
+            totalChecks:
+              type: integer
+            passing:
+              type: integer
+            failing:
+              type: integer
+            warnings:
+              type: integer
+    AdminHealthCheck:
+      type: object
+      required: [name, status, message, duration, lastChecked]
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum: [passing, warning, critical]
+        message:
+          type: string
+        duration:
+          type: number
+        lastChecked:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: {}
+    RegistryReloadResult:
+      type: object
+      required: [success, timestamp, componentsDiscovered, componentsLoaded, errors, newComponents, updatedComponents, removedComponents]
+      properties:
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        componentsDiscovered:
+          type: integer
+        componentsLoaded:
+          type: integer
+        errors:
+          type: array
+          items:
+            type: string
+        newComponents:
+          type: array
+          items:
+            type: string
+        updatedComponents:
+          type: array
+          items:
+            type: string
+        removedComponents:
+          type: array
+          items:
+            type: string
+    AuditLogEntry:
+      type: object
+      required: [id, timestamp, service, action, actor, target, metadata, severity, complianceRelevant]
+      properties:
+        id:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        service:
+          type: string
+        component:
+          type: string
+        action:
+          type: string
+        actor:
+          $ref: '#/components/schemas/AuditActor'
+        target:
+          $ref: '#/components/schemas/AuditTarget'
+        changes:
+          type: object
+          properties:
+            before:
+              type: object
+              additionalProperties: {}
+            after:
+              type: object
+              additionalProperties: {}
+        metadata:
+          type: object
+          additionalProperties: {}
+        severity:
+          type: string
+          enum: [info, warning, critical]
+        complianceRelevant:
+          type: boolean
+    AuditActor:
+      type: object
+      required: [type, id, name]
+      properties:
+        type:
+          type: string
+          enum: [user, system, automation]
+        id:
+          type: string
+        name:
+          type: string
+    AuditTarget:
+      type: object
+      required: [type, id, name]
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+    DependencyGraph:
+      type: object
+      required: [services, edges, metadata]
+      properties:
+        services:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceNode'
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/DependencyEdge'
+        metadata:
+          type: object
+          required: [totalServices, totalBindings, generatedAt, criticalPaths]
+          properties:
+            totalServices:
+              type: integer
+            totalBindings:
+              type: integer
+            generatedAt:
+              type: string
+              format: date-time
+            criticalPaths:
+              type: array
+              items:
+                $ref: '#/components/schemas/CriticalPath'
+    ServiceNode:
+      type: object
+      required: [name, owner, complianceFramework, environment, components, status, criticality]
+      properties:
+        name:
+          type: string
+        owner:
+          type: string
+        complianceFramework:
+          type: string
+        environment:
+          type: string
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComponentNode'
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy, unknown]
+        criticality:
+          type: string
+          enum: [low, medium, high, critical]
+    ComponentNode:
+      type: object
+      required: [name, type, capabilities, bindings]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/BindingNode'
+    BindingNode:
+      type: object
+      required: [target, capability, access, type]
+      properties:
+        target:
+          type: string
+        capability:
+          type: string
+        access:
+          type: string
+        type:
+          type: string
+          enum: [inbound, outbound]
+    DependencyEdge:
+      type: object
+      required: [source, target, component, capability, access, strength]
+      properties:
+        source:
+          type: string
+        target:
+          type: string
+        component:
+          type: string
+        capability:
+          type: string
+        access:
+          type: string
+        strength:
+          type: string
+          enum: [weak, strong, critical]
+    CriticalPath:
+      type: object
+      required: [path, description, riskLevel, impactRadius]
+      properties:
+        path:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        riskLevel:
+          type: string
+          enum: [low, medium, high, critical]
+        impactRadius:
+          type: integer
+    DriftDetectionResult:
+      type: object
+      required: [service, environment, overallStatus, scannedAt, components, summary]
+      properties:
+        service:
+          type: string
+        environment:
+          type: string
+        overallStatus:
+          type: string
+          enum: [no-drift, drift-detected, scan-failed]
+        scannedAt:
+          type: string
+          format: date-time
+        components:
+          type: array
+          items:
+            $ref: '#/components/schemas/ComponentDriftStatus'
+        summary:
+          type: object
+          required: [totalComponents, componentsWithDrift, totalDrifts, criticalDrifts]
+          properties:
+            totalComponents:
+              type: integer
+            componentsWithDrift:
+              type: integer
+            totalDrifts:
+              type: integer
+            criticalDrifts:
+              type: integer
+    ComponentDriftStatus:
+      type: object
+      required: [name, type, status, drifts]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+          enum: [no-drift, drift-detected, scan-failed]
+        drifts:
+          type: array
+          items:
+            $ref: '#/components/schemas/DriftItem'
+    DriftItem:
+      type: object
+      required: [resourceType, resourceId, property, expectedValue, actualValue, severity, category, remediation]
+      properties:
+        resourceType:
+          type: string
+        resourceId:
+          type: string
+        property:
+          type: string
+        expectedValue:
+          type: string
+        actualValue:
+          type: string
+        severity:
+          type: string
+          enum: [low, medium, high, critical]
+        category:
+          type: string
+          enum: [configuration, security, performance, compliance]
+        remediation:
+          type: string


### PR DESCRIPTION
## Summary
- document every REST surface exposed by the MCP server, including platform, service, generative, admin, and health endpoints
- add comprehensive schema components covering service catalogs, runtime telemetry, audit trails, dependency graphs, and drift scans
- define bearer JWT security, grouped tags, and environment-specific server URLs to guide API consumers

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8a40b127483338d1e71443e736286