### PR TITLE
Stabilize resolver tests and add binding/SG/IAM/env validations

### DIFF
--- a/packages/core/src/platform/contracts/__tests__/component-registration-failures.test.ts
+++ b/packages/core/src/platform/contracts/__tests__/component-registration-failures.test.ts
@@ -1,0 +1,35 @@
+import { ComponentFactoryBuilder } from '../components/component-factory.js';
+import { ComponentRegistry } from '../components/component-registry.js';
+import type { ComponentContext } from '../components/component-context.js';
+
+class ValidComponent {
+  constructor() {}
+  getName() { return 'valid'; }
+  getId() { return 'valid'; }
+  getType() { return 'valid'; }
+  getCapabilityData() { return { type: 'test', resources: {} }; }
+  getServiceName() { return 'service'; }
+  synth() { return undefined; }
+}
+
+describe('ComponentRegistry__Failures', () => {
+  it('ComponentRegistration__MissingDist__ClearError', () => {
+    const factory = new ComponentFactoryBuilder().build();
+    const context = { scope: {} } as ComponentContext;
+    expect(() => factory.create('missing-component', context, { name: 'missing', type: 'missing-component', config: {} }))
+      .toThrow('Unsupported component type');
+  });
+
+  it('ComponentRegistration__ModuleResolutionFailure__ClearError', () => {
+    const registry = new ComponentRegistry();
+    expect(() => registry.register('invalid', null as any)).toThrow('Component class must be a constructor function');
+  });
+
+  it('ComponentRegistration__DiscoveryRobustness__Fallbacks', () => {
+    const registry = new ComponentRegistry();
+    registry.register('valid', ValidComponent as any);
+    expect(registry.hasComponent('valid')).toBe(true);
+    expect(() => registry.register('', ValidComponent as any)).toThrow('Component type must be a non-empty string');
+    expect(registry.hasComponent('valid')).toBe(true);
+  });
+});

--- a/packages/core/src/platform/contracts/__tests__/configbuilder-determinism.test.ts
+++ b/packages/core/src/platform/contracts/__tests__/configbuilder-determinism.test.ts
@@ -1,0 +1,60 @@
+import * as childProcess from 'child_process';
+import { ConfigBuilder } from '../config-builder.js';
+import type { ComponentContext, ComponentSpec } from '../component-interfaces.js';
+
+class DeterministicConfigBuilder extends ConfigBuilder<Record<string, any>> {
+  protected getHardcodedFallbacks(): Record<string, any> {
+    return { enabled: true };
+  }
+}
+
+const createContext = (): ComponentContext => ({
+  serviceName: 'test-service',
+  environment: 'test',
+  complianceFramework: 'commercial',
+  scope: {} as any
+});
+
+describe('ConfigBuilder__Determinism', () => {
+  it('ConfigBuilderDeterminism__NetworkCall__Detected', () => {
+    const originalFetch = global.fetch;
+    const fetchSpy = jest.fn(() => Promise.resolve({}));
+    // @ts-expect-error allow override for test
+    global.fetch = fetchSpy;
+
+    const spec: ComponentSpec = { name: 'component', type: 'vpc', config: {} };
+    const builder = new DeterministicConfigBuilder({ context: createContext(), spec }, {
+      type: 'object',
+      properties: {}
+    });
+
+    builder.buildSync();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    global.fetch = originalFetch;
+  });
+
+  it('ConfigBuilderDeterminism__CliExecution__Detected', () => {
+    const execSpy = jest.spyOn(childProcess, 'execSync');
+
+    const spec: ComponentSpec = { name: 'component', type: 'vpc', config: {} };
+    const builder = new DeterministicConfigBuilder({ context: createContext(), spec }, {
+      type: 'object',
+      properties: {}
+    });
+
+    builder.buildSync();
+    expect(execSpy).not.toHaveBeenCalled();
+    execSpy.mockRestore();
+  });
+
+  it('ConfigBuilderDeterminism__StaticAnalysis__AllBuilders', () => {
+    const spec: ComponentSpec = { name: 'component', type: 'vpc', config: {} };
+    const builder = new DeterministicConfigBuilder({ context: createContext(), spec }, {
+      type: 'object',
+      properties: {}
+    });
+
+    const config = builder.buildSync();
+    expect(config.enabled).toBe(true);
+  });
+});

--- a/packages/core/src/platform/networking/__tests__/cross-stack-binding-limitations.test.ts
+++ b/packages/core/src/platform/networking/__tests__/cross-stack-binding-limitations.test.ts
@@ -1,0 +1,74 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { CrossStackRuleManager, type CrossStackRuleSpec } from '../cross-stack-rule-manager.js';
+
+describe('CrossStackRuleManager__Limitations', () => {
+  it('CrossStackBinding__LimitationsDocumented__ClearErrors', () => {
+    const app = new cdk.App();
+    const invalidRule: CrossStackRuleSpec = {
+      ruleId: 'rule-1',
+      targetSecurityGroupId: 'sg-123456',
+      rule: {
+        type: 'ingress',
+        peer: { kind: 'invalid', id: 'sg-123456' } as any,
+        port: { from: 80, to: 80, protocol: 'tcp' },
+        description: 'Invalid peer'
+      },
+      sourceComponent: 'source',
+      targetComponent: 'target',
+      bindingId: 'source-target-security-group-rule',
+      timestamp: new Date().toISOString()
+    };
+
+    expect(() => CrossStackRuleManager.createNetworkRulesStack(app, [invalidRule]))
+      .toThrow('Unknown peer kind');
+  });
+
+  it('CrossStackBinding__SecurityGroupRules__Works', () => {
+    const app = new cdk.App();
+    const rule: CrossStackRuleSpec = {
+      ruleId: 'rule-1',
+      targetSecurityGroupId: 'sg-123456',
+      rule: {
+        type: 'ingress',
+        peer: { kind: 'cidr', cidr: '10.0.0.0/16' },
+        port: { from: 443, to: 443, protocol: 'tcp' },
+        description: 'Allow HTTPS'
+      },
+      sourceComponent: 'source',
+      targetComponent: 'target',
+      bindingId: 'source-target-security-group-rule',
+      timestamp: new Date().toISOString()
+    };
+
+    const stack = CrossStackRuleManager.createNetworkRulesStack(app, [rule], 'NetworkRulesStack');
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::EC2::SecurityGroupIngress', 1);
+  });
+
+  it('CrossStackBinding__Validation__PreSynthesis', () => {
+    const app = new cdk.App();
+    const rule: CrossStackRuleSpec = {
+      ruleId: 'rule-1',
+      targetSecurityGroupId: 'sg-123456',
+      rule: {
+        type: 'ingress',
+        peer: { kind: 'cidr', cidr: '10.0.0.0/16' },
+        port: { from: 22, to: 22, protocol: 'tcp' },
+        description: 'Allow SSH'
+      },
+      sourceComponent: 'source',
+      targetComponent: 'target',
+      bindingId: 'source-target-security-group-rule',
+      timestamp: new Date().toISOString()
+    };
+    const duplicateRule: CrossStackRuleSpec = {
+      ...rule,
+      ruleId: 'rule-2'
+    };
+
+    const stack = CrossStackRuleManager.createNetworkRulesStack(app, [rule, duplicateRule], 'NetworkRulesStack');
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::EC2::SecurityGroupIngress', 1);
+  });
+});

--- a/packages/core/src/resolver/__tests__/capability-data-versioning.test.ts
+++ b/packages/core/src/resolver/__tests__/capability-data-versioning.test.ts
@@ -1,0 +1,90 @@
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__CapabilityVersioning', () => {
+  it('CapabilityVersioning__VersionMismatch__Handled', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': { version: 1, resources: { apiId: 'abc' } } }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read', options: { expectedVersion: 2 } }];
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async (context) => {
+        const capability = context.target.getCapabilities()['api:rest'];
+        if (capability.version !== context.directive.options?.expectedVersion) {
+          throw new Error(`Capability version mismatch: ${capability.version} != ${context.directive.options?.expectedVersion}`);
+        }
+        return {
+          environmentVariables: {},
+          iamPolicies: [],
+          securityGroupRules: [],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        };
+      }
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {}))
+      .rejects
+      .toThrow('Capability version mismatch');
+  });
+
+  it('CapabilityVersioning__BackwardCompatibility__Maintained', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': { version: 1, resources: { apiId: 'abc' } } }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read', options: { expectedVersion: 1 } }];
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async () => ({
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      })
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await (resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {});
+  });
+
+  it('CapabilityVersioning__VersionRegistry__Tracking', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': { version: 2, resources: { apiId: 'abc' } } }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read', options: { expectedVersion: 2 } }];
+
+    const versionRegistry = new Map<string, number>();
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async (context) => {
+        const capability = context.target.getCapabilities()['api:rest'];
+        versionRegistry.set(context.target.spec.name, capability.version);
+        return {
+          environmentVariables: {},
+          iamPolicies: [],
+          securityGroupRules: [],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        };
+      }
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await (resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {});
+
+    expect(versionRegistry.get('api')).toBe(2);
+  });
+});

--- a/packages/core/src/resolver/__tests__/patch-application-timing.test.ts
+++ b/packages/core/src/resolver/__tests__/patch-application-timing.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import { createMockBinderRegistry, createTestResolverEngine, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__PatchTiming', () => {
+  const createTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'patch-tests-'));
+
+  it('PatchTiming__PatchModifiesConstruct__ComponentUsesAfter__Inconsistency', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      const patchFile = path.join(tempDir, 'patches.js');
+      fs.writeFileSync(
+        patchFile,
+        `
+        export async function applyPatches({ constructs }) {
+          constructs.api.node.addMetadata('patched', true);
+        }
+        `,
+        'utf8'
+      );
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const apiConstruct = new cdk.CfnResource(stack, 'Api', { type: 'Custom::Api' });
+      const component = new MockComponent(stack, 'ApiComponent', {
+        name: 'api',
+        type: 'api-gateway-rest',
+        constructs: { main: apiConstruct }
+      });
+
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]) });
+      const patchesApplied = await (resolver as any).applyPatches(stack, [component], {});
+
+      expect(patchesApplied).toBe(true);
+      expect(apiConstruct.node.metadata.some(entry => entry.type === 'patched')).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('PatchTiming__PreSynthesisPatch__WorksCorrectly', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      const patchFile = path.join(tempDir, 'patches.js');
+      fs.writeFileSync(
+        patchFile,
+        `
+        export async function applyPatches({ constructs }) {
+          constructs.worker.node.addMetadata('pre-synthesis', true);
+        }
+        `,
+        'utf8'
+      );
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const workerConstruct = new cdk.CfnResource(stack, 'Worker', { type: 'Custom::Worker' });
+      const component = new MockComponent(stack, 'WorkerComponent', {
+        name: 'worker',
+        type: 'lambda-api',
+        constructs: { main: workerConstruct }
+      });
+
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]) });
+      const patchesApplied = await (resolver as any).applyPatches(stack, [component], {});
+
+      expect(patchesApplied).toBe(true);
+      expect(workerConstruct.node.metadata.some(entry => entry.type === 'pre-synthesis')).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('PatchTiming__PatchValidation__DetectsConflicts', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      const patchFile = path.join(tempDir, 'patches.js');
+      fs.writeFileSync(
+        patchFile,
+        `
+        export async function applyPatches() {
+          throw new Error('Patch conflict detected');
+        }
+        `,
+        'utf8'
+      );
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const component = new MockComponent(stack, 'Component', {
+        name: 'component',
+        type: 'lambda-api'
+      });
+
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]) });
+
+      await expect((resolver as any).applyPatches(stack, [component], {}))
+        .rejects
+        .toThrow('Patch application failed: Patch conflict detected');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/packages/core/src/resolver/__tests__/patch-file-loading.test.ts
+++ b/packages/core/src/resolver/__tests__/patch-file-loading.test.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import { createMockBinderRegistry, createTestLogger, createTestResolverEngine, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__PatchFileLoading', () => {
+  const createTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'patch-loading-'));
+
+  it('PatchLoading__PathResolutionFailure__ClearError', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const component = new MockComponent(stack, 'Component', { name: 'component', type: 'lambda-api' });
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]) });
+
+      const applied = await (resolver as any).applyPatches(stack, [component], {});
+      expect(applied).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('PatchLoading__SyntaxError__ClearError', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      fs.writeFileSync(path.join(tempDir, 'patches.js'), 'export const =;', 'utf8');
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const component = new MockComponent(stack, 'Component', { name: 'component', type: 'lambda-api' });
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]) });
+
+      await expect((resolver as any).applyPatches(stack, [component], {}))
+        .rejects
+        .toThrow('Patch application failed');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('PatchLoading__MissingExport__ClearError', async () => {
+    const tempDir = createTempDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tempDir);
+
+      fs.writeFileSync(path.join(tempDir, 'patches.js'), 'export const patchInfo = {};', 'utf8');
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, 'TestStack');
+      const component = new MockComponent(stack, 'Component', { name: 'component', type: 'lambda-api' });
+      const logger = createTestLogger();
+      const resolver = createTestResolverEngine({ binderRegistry: createMockBinderRegistry([]), logger });
+
+      const applied = await (resolver as any).applyPatches(stack, [component], {});
+      expect(applied).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith('patches.ts exists but does not export applyPatches function');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-binding-target-failure.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-binding-target-failure.test.ts
@@ -1,0 +1,73 @@
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__BindingTargetFailure', () => {
+  it('BindingTarget__TargetSynthesisFails__ClearError', async () => {
+    const stack = createTestStack();
+    const failingComponent = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      onSynth: () => {
+        throw new Error('Invalid config');
+      }
+    });
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([])
+    });
+
+    await expect((resolver as any).synthesizeComponents([failingComponent]))
+      .rejects
+      .toThrow("Failed to synthesize component 'api': Invalid config");
+  });
+
+  it('BindingTarget__TargetMissingFromOutputs__ClearError', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', {
+      name: 'lambda',
+      type: 'lambda-api'
+    });
+    source.spec.binds = [{ to: 'missing-api', capability: 'api:rest', access: 'read' }];
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async () => ({
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      })
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([source], createOutputsMap([source]), {}))
+      .rejects
+      .toThrow('Cannot resolve binding target for directive');
+  });
+
+  it('BindingTarget__PreBindingValidation__CatchesEarly', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', {
+      name: 'lambda',
+      type: 'lambda-api'
+    });
+    source.spec.binds = [{ to: 'missing-api', capability: 'api:rest', access: 'read' }];
+
+    const bindSpy = jest.fn(async () => ({
+      environmentVariables: {},
+      iamPolicies: [],
+      securityGroupRules: [],
+      compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+    }));
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: bindSpy
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([source], createOutputsMap([source]), {}))
+      .rejects
+      .toThrow('Cannot resolve binding target');
+    expect(bindSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-capability-mismatches.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-capability-mismatches.test.ts
@@ -1,0 +1,79 @@
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__CapabilityMismatches', () => {
+  const createCapabilityValidatingStrategy = () => createMockBinderStrategy({
+    supportedCapabilities: ['api:rest'],
+    bind: async (context) => {
+      const capability = context.target.getCapabilities()['api:rest'];
+      if (!capability || typeof capability !== 'object') {
+        throw new Error('Capability data must be an object');
+      }
+      if (!capability.resources?.apiId) {
+        throw new Error('Missing required field: resources.apiId');
+      }
+      return {
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      };
+    }
+  });
+
+  it('CapabilityMismatch__MissingRequiredFields__ClearError', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': { resources: {} } }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read' }];
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createCapabilityValidatingStrategy()])
+    });
+
+    await expect((resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {}))
+      .rejects
+      .toThrow('Missing required field: resources.apiId');
+  });
+
+  it('CapabilityMismatch__WrongStructure__ClearError', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': 'invalid' as any }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read' }];
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createCapabilityValidatingStrategy()])
+    });
+
+    await expect((resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {}))
+      .rejects
+      .toThrow('Capability data must be an object');
+  });
+
+  it('CapabilityMismatch__SchemaValidation__PreBinding', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'Api', {
+      name: 'api',
+      type: 'api-gateway-rest',
+      capabilities: { 'api:rest': { resources: {} } }
+    });
+    source.spec.binds = [{ to: 'api', capability: 'api:rest', access: 'read' }];
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createCapabilityValidatingStrategy()])
+    });
+
+    await expect((resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {}))
+      .rejects
+      .toThrow('Missing required field');
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-circular-bindings.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-circular-bindings.test.ts
@@ -1,0 +1,77 @@
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__CircularBindings', () => {
+  it('CircularBindings__DirectCycle__DetectedEarly', async () => {
+    const stack = createTestStack();
+    const componentA = new MockComponent(stack, 'ServiceA', { name: 'service-a', type: 'lambda-api' });
+    const componentB = new MockComponent(stack, 'ServiceB', { name: 'service-b', type: 'lambda-api' });
+    componentA.spec.binds = [{ to: 'service-b', capability: 'api:rest', access: 'read' }];
+    componentB.spec.binds = [{ to: 'service-a', capability: 'api:rest', access: 'read' }];
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async () => ({
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      })
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([componentA, componentB], createOutputsMap([componentA, componentB]), {}))
+      .rejects
+      .toThrow('Circular binding dependency detected');
+  });
+
+  it('CircularBindings__IndirectCycle__DetectedEarly', async () => {
+    const stack = createTestStack();
+    const componentA = new MockComponent(stack, 'ServiceA', { name: 'service-a', type: 'lambda-api' });
+    const componentB = new MockComponent(stack, 'ServiceB', { name: 'service-b', type: 'lambda-api' });
+    const componentC = new MockComponent(stack, 'ServiceC', { name: 'service-c', type: 'lambda-api' });
+    componentA.spec.binds = [{ to: 'service-b', capability: 'api:rest', access: 'read' }];
+    componentB.spec.binds = [{ to: 'service-c', capability: 'api:rest', access: 'read' }];
+    componentC.spec.binds = [{ to: 'service-a', capability: 'api:rest', access: 'read' }];
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: async () => ({
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      })
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([componentA, componentB, componentC], createOutputsMap([componentA, componentB, componentC]), {}))
+      .rejects
+      .toThrow('Circular binding dependency detected');
+  });
+
+  it('CircularBindings__BindingGraphValidation__PreSynthesis', async () => {
+    const stack = createTestStack();
+    const componentA = new MockComponent(stack, 'ServiceA', { name: 'service-a', type: 'lambda-api' });
+    const componentB = new MockComponent(stack, 'ServiceB', { name: 'service-b', type: 'lambda-api' });
+    componentA.spec.binds = [{ to: 'service-b', capability: 'api:rest', access: 'read' }];
+    componentB.spec.binds = [{ to: 'service-a', capability: 'api:rest', access: 'read' }];
+
+    const bindSpy = jest.fn(async () => ({
+      environmentVariables: {},
+      iamPolicies: [],
+      securityGroupRules: [],
+      compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+    }));
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['api:rest'],
+      bind: bindSpy
+    })]);
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await expect((resolver as any).bindComponents([componentA, componentB], createOutputsMap([componentA, componentB]), {}))
+      .rejects
+      .toThrow('Circular binding dependency detected');
+    expect(bindSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-context-injection.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-context-injection.test.ts
@@ -1,0 +1,71 @@
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__ContextInjectionTiming', () => {
+  it('ContextInjection__VpcBindingBeforeSynthesis__ContextAvailable', async () => {
+    const stack = createTestStack();
+    const vpcStub = {} as IVpc;
+    const component = new MockComponent(stack, 'Db', {
+      name: 'rds',
+      type: 'rds-postgres',
+      contextOverrides: { vpc: vpcStub },
+      onSynth: () => {
+        expect(component.context.vpc).toBe(vpcStub);
+      }
+    });
+
+    const registry = createMockBinderRegistry([createMockBinderStrategy({
+      supportedCapabilities: ['networking:vpc'],
+      bind: async () => ({
+        environmentVariables: {},
+        iamPolicies: [],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      })
+    })]);
+
+    const resolver = createTestResolverEngine({ binderRegistry: registry });
+
+    await (resolver as any).synthesizeComponents([component]);
+  });
+
+  it('ContextInjection__VpcBindingAfterSynthesis__FailsGracefully', async () => {
+    const stack = createTestStack();
+    const component = new MockComponent(stack, 'Db', {
+      name: 'rds',
+      type: 'rds-postgres',
+      onSynth: () => {
+        if (!component.context.vpc) {
+          throw new Error('VPC context not available');
+        }
+      }
+    });
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([])
+    });
+
+    await expect((resolver as any).synthesizeComponents([component]))
+      .rejects
+      .toThrow("Failed to synthesize component 'rds': VPC context not available");
+  });
+
+  it('ContextInjection__LazyResolution__DeferredAccess', async () => {
+    const stack = createTestStack();
+    const component = new MockComponent(stack, 'Db', {
+      name: 'rds',
+      type: 'rds-postgres'
+    });
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([])
+    });
+
+    const outputsMap = await (resolver as any).synthesizeComponents([component]);
+    expect(outputsMap.get('rds')).toBeDefined();
+
+    const vpcStub = {} as IVpc;
+    component.context.vpc = vpcStub;
+    expect(component.context.vpc).toBe(vpcStub);
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-env-var-conflicts.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-env-var-conflicts.test.ts
@@ -1,0 +1,79 @@
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestLogger, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__EnvVarConflicts', () => {
+  const createEnvVarStrategy = () => createMockBinderStrategy({
+    supportedCapabilities: ['networking:vpc'],
+    bind: async (context) => ({
+      environmentVariables: context.directive.env ?? {},
+      iamPolicies: [],
+      securityGroupRules: [],
+      compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+    })
+  });
+
+  it('EnvVarConflicts__DuplicateVariables__Detected', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const targetA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const targetB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createEnvVarStrategy()]),
+      logger
+    });
+
+    await (resolver as any).bindComponents([source, targetA, targetB], createOutputsMap([source, targetA, targetB]), {});
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Environment variable conflict for VPC_ID'));
+  });
+
+  it('EnvVarConflicts__LastBindingWins__Logged', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const targetA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const targetB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createEnvVarStrategy()]),
+      logger
+    });
+
+    await (resolver as any).bindComponents([source, targetA, targetB], createOutputsMap([source, targetA, targetB]), {});
+
+    const warningCalls = (logger.warn as jest.Mock).mock.calls.flat().join(' ');
+    expect(warningCalls).toContain('overwritten');
+    expect(warningCalls).toContain('vpc-a');
+    expect(warningCalls).toContain('vpc-b');
+  });
+
+  it('EnvVarConflicts__NamespacedVariables__NoConflict', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const targetA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const targetB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_A_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_B_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createEnvVarStrategy()]),
+      logger
+    });
+
+    await (resolver as any).bindComponents([source, targetA, targetB], createOutputsMap([source, targetA, targetB]), {});
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/resolver/__tests__/resolver-engine-iam-policy-conflicts.test.ts
+++ b/packages/core/src/resolver/__tests__/resolver-engine-iam-policy-conflicts.test.ts
@@ -1,0 +1,86 @@
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { createMockBinderRegistry, createMockBinderStrategy, createOutputsMap, createTestLogger, createTestResolverEngine, createTestStack, MockComponent } from './test-helpers.js';
+
+describe('ResolverEngine__IamPolicyConflicts', () => {
+  const createIamStrategy = () => createMockBinderStrategy({
+    supportedCapabilities: ['storage:s3'],
+    bind: async (context) => {
+      const options = context.directive.options ?? {};
+      const statement = new PolicyStatement({
+        effect: options.effect ?? Effect.ALLOW,
+        actions: options.actions ?? [],
+        resources: options.resources ?? []
+      });
+
+      return {
+        environmentVariables: {},
+        iamPolicies: [{
+          statement,
+          description: 'test-policy',
+          complianceRequirement: 'unit-test'
+        }],
+        securityGroupRules: [],
+        compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+      };
+    }
+  });
+
+  it('IamPolicyConflicts__ConflictingPolicies__Detected', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const targetA = new MockComponent(stack, 'BucketA', { name: 'bucket-a', type: 's3-bucket' });
+    const targetB = new MockComponent(stack, 'BucketB', { name: 'bucket-b', type: 's3-bucket' });
+    source.spec.binds = [
+      { to: 'bucket-a', capability: 'storage:s3', access: 'read', options: { actions: ['s3:GetObject'], resources: ['arn:aws:s3:::bucket'], effect: Effect.ALLOW } },
+      { to: 'bucket-b', capability: 'storage:s3', access: 'read', options: { actions: ['s3:GetObject'], resources: ['arn:aws:s3:::bucket'], effect: Effect.DENY } }
+    ];
+
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createIamStrategy()])
+    });
+
+    await expect((resolver as any).bindComponents([source, targetA, targetB], createOutputsMap([source, targetA, targetB]), {}))
+      .rejects
+      .toThrow('Conflicting IAM policy effects');
+  });
+
+  it('IamPolicyConflicts__PolicyMerging__CorrectResult', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const targetA = new MockComponent(stack, 'BucketA', { name: 'bucket-a', type: 's3-bucket' });
+    const targetB = new MockComponent(stack, 'BucketB', { name: 'bucket-b', type: 's3-bucket' });
+    source.spec.binds = [
+      { to: 'bucket-a', capability: 'storage:s3', access: 'read', options: { actions: ['s3:GetObject'], resources: ['arn:aws:s3:::bucket'], effect: Effect.ALLOW } },
+      { to: 'bucket-b', capability: 'storage:s3', access: 'read', options: { actions: ['s3:PutObject'], resources: ['arn:aws:s3:::bucket'], effect: Effect.ALLOW } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createIamStrategy()]),
+      logger
+    });
+
+    await (resolver as any).bindComponents([source, targetA, targetB], createOutputsMap([source, targetA, targetB]), {});
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Merged IAM actions'));
+  });
+
+  it('IamPolicyConflicts__OverPrivileging__Detected', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const target = new MockComponent(stack, 'BucketA', { name: 'bucket-a', type: 's3-bucket' });
+    source.spec.binds = [
+      { to: 'bucket-a', capability: 'storage:s3', access: 'read', options: { actions: ['s3:*'], resources: ['arn:aws:s3:::bucket'], effect: Effect.ALLOW } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = createTestResolverEngine({
+      binderRegistry: createMockBinderRegistry([createIamStrategy()]),
+      logger
+    });
+
+    await (resolver as any).bindComponents([source, target], createOutputsMap([source, target]), {});
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Over-privileging detected'));
+  });
+});

--- a/packages/core/src/resolver/__tests__/security-group-rule-timing.test.ts
+++ b/packages/core/src/resolver/__tests__/security-group-rule-timing.test.ts
@@ -1,0 +1,160 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Template } from 'aws-cdk-lib/assertions';
+import { SecurityGroupRulePostProcessor } from '../security-group-rule-post-processor.js';
+import type { EnhancedBindingResult } from '../../platform/contracts/platform-binding-trigger-spec.js';
+
+const createStackWithSecurityGroups = () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'TestStack', { env: { account: '123456789012', region: 'us-east-1' } });
+  const targetSecurityGroup = new ec2.CfnSecurityGroup(stack, 'TargetSG', {
+    groupDescription: 'Target SG',
+    vpcId: 'vpc-12345678',
+    tags: [{ key: 'resource-type', value: 'security-group' }]
+  });
+  const sourceSecurityGroup = new ec2.CfnSecurityGroup(stack, 'SourceSG', {
+    groupDescription: 'Source SG',
+    vpcId: 'vpc-12345678',
+    tags: [{ key: 'resource-type', value: 'security-group' }]
+  });
+  return { stack, targetSecurityGroup, sourceSecurityGroup };
+};
+
+describe('SecurityGroupRulePostProcessor__Timing', () => {
+  it('SGRuleTiming__ComponentCreatesRule__PostProcessorApplies__NoDuplicate', () => {
+    const { stack, targetSecurityGroup, sourceSecurityGroup } = createStackWithSecurityGroups();
+    const bindings = [
+      {
+        source: 'lambda-a',
+        target: 'rds',
+        capability: 'security-group:rule',
+        result: {
+          environmentVariables: {
+            SECURITY_GROUP_RULE_TARGET_SG_ID: targetSecurityGroup.ref
+          },
+          iamPolicies: [],
+          securityGroupRules: [
+            {
+              type: 'ingress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 5432, to: 5432, protocol: 'tcp' as const },
+              description: 'Allow DB'
+            }
+          ],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        } as EnhancedBindingResult
+      },
+      {
+        source: 'lambda-b',
+        target: 'rds',
+        capability: 'security-group:rule',
+        result: {
+          environmentVariables: {
+            SECURITY_GROUP_RULE_TARGET_SG_ID: targetSecurityGroup.ref
+          },
+          iamPolicies: [],
+          securityGroupRules: [
+            {
+              type: 'ingress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 5432, to: 5432, protocol: 'tcp' as const },
+              description: 'Allow DB'
+            }
+          ],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        } as EnhancedBindingResult
+      }
+    ];
+
+    SecurityGroupRulePostProcessor.process(bindings, stack, [], 'test-service');
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::EC2::SecurityGroupIngress', 1);
+  });
+
+  it('SGRuleTiming__ConflictingRules__Detected', () => {
+    const { stack, targetSecurityGroup, sourceSecurityGroup } = createStackWithSecurityGroups();
+    const bindings = [
+      {
+        source: 'lambda-a',
+        target: 'rds',
+        capability: 'security-group:rule',
+        result: {
+          environmentVariables: {
+            SECURITY_GROUP_RULE_TARGET_SG_ID: targetSecurityGroup.ref
+          },
+          iamPolicies: [],
+          securityGroupRules: [
+            {
+              type: 'ingress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 5432, to: 5432, protocol: 'tcp' as const },
+              description: 'Allow DB'
+            },
+            {
+              type: 'egress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 5432, to: 5432, protocol: 'tcp' as const },
+              description: 'Conflicting rule'
+            }
+          ],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        } as EnhancedBindingResult
+      }
+    ];
+
+    expect(() => SecurityGroupRulePostProcessor.process(bindings, stack, [], 'test-service'))
+      .toThrow('Conflicting security group rules');
+  });
+
+  it('SGRuleTiming__RuleDeduplication__Works', () => {
+    const { stack, targetSecurityGroup, sourceSecurityGroup } = createStackWithSecurityGroups();
+    const bindings = [
+      {
+        source: 'lambda-a',
+        target: 'rds',
+        capability: 'security-group:rule',
+        result: {
+          environmentVariables: {
+            SECURITY_GROUP_RULE_TARGET_SG_ID: targetSecurityGroup.ref
+          },
+          iamPolicies: [],
+          securityGroupRules: [
+            {
+              type: 'ingress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 443, to: 443, protocol: 'tcp' as const },
+              description: 'Allow HTTPS'
+            }
+          ],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        } as EnhancedBindingResult
+      },
+      {
+        source: 'lambda-b',
+        target: 'rds',
+        capability: 'security-group:rule',
+        result: {
+          environmentVariables: {
+            SECURITY_GROUP_RULE_TARGET_SG_ID: targetSecurityGroup.ref
+          },
+          iamPolicies: [],
+          securityGroupRules: [
+            {
+              type: 'ingress' as const,
+              peer: { kind: 'sg' as const, id: sourceSecurityGroup.ref },
+              port: { from: 443, to: 443, protocol: 'tcp' as const },
+              description: 'Allow HTTPS'
+            }
+          ],
+          compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+        } as EnhancedBindingResult
+      }
+    ];
+
+    SecurityGroupRulePostProcessor.process(bindings, stack, [], 'test-service');
+
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::EC2::SecurityGroupIngress', 1);
+  });
+});

--- a/packages/core/src/resolver/__tests__/test-fixtures.ts
+++ b/packages/core/src/resolver/__tests__/test-fixtures.ts
@@ -1,0 +1,60 @@
+export const TestFixtures = {
+  manifestWithVpcBinding: () => ({
+    service: 'test-service',
+    owner: 'platform-team',
+    complianceFramework: 'commercial',
+    environment: 'test',
+    components: [
+      { name: 'rds', type: 'rds-postgres', config: { vpc: { enabled: true } }, binds: [{ to: 'vpc', capability: 'networking:vpc', access: 'read' }] },
+      { name: 'vpc', type: 'vpc', config: {} }
+    ]
+  }),
+  manifestWithCircularBindings: () => ({
+    service: 'test-service',
+    owner: 'platform-team',
+    complianceFramework: 'commercial',
+    environment: 'test',
+    components: [
+      { name: 'service-a', type: 'lambda-api', config: {}, binds: [{ to: 'service-b', capability: 'api:rest', access: 'read' }] },
+      { name: 'service-b', type: 'lambda-api', config: {}, binds: [{ to: 'service-a', capability: 'api:rest', access: 'read' }] }
+    ]
+  }),
+  manifestWithEnvVarConflict: () => ({
+    service: 'test-service',
+    owner: 'platform-team',
+    complianceFramework: 'commercial',
+    environment: 'test',
+    components: [
+      { name: 'vpc-a', type: 'vpc', config: {} },
+      { name: 'vpc-b', type: 'vpc', config: {} },
+      {
+        name: 'lambda',
+        type: 'lambda-api',
+        config: {},
+        binds: [
+          { to: 'vpc-a', capability: 'networking:vpc', access: 'read' },
+          { to: 'vpc-b', capability: 'networking:vpc', access: 'read' }
+        ]
+      }
+    ]
+  }),
+  manifestWithPolicyConflict: () => ({
+    service: 'test-service',
+    owner: 'platform-team',
+    complianceFramework: 'commercial',
+    environment: 'test',
+    components: [
+      { name: 'bucket-a', type: 's3-bucket', config: {} },
+      { name: 'bucket-b', type: 's3-bucket', config: {} },
+      {
+        name: 'lambda',
+        type: 'lambda-api',
+        config: {},
+        binds: [
+          { to: 'bucket-a', capability: 'storage:s3', access: 'read' },
+          { to: 'bucket-b', capability: 'storage:s3', access: 'write' }
+        ]
+      }
+    ]
+  })
+};

--- a/packages/core/src/resolver/__tests__/test-helpers.ts
+++ b/packages/core/src/resolver/__tests__/test-helpers.ts
@@ -1,0 +1,157 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { ResolverEngine } from '../resolver-engine.js';
+import { UnifiedBinderRegistry } from '../../platform/binders/registry/unified-binder-registry.js';
+import type {
+  ComponentCapabilities,
+  ComponentContext,
+  ComponentSpec,
+  IComponent
+} from '../../platform/contracts/component-interfaces.js';
+import type {
+  BindingContext,
+  EnhancedBindingResult,
+  CompatibilityEntry,
+  IUnifiedBinderStrategy
+} from '../../platform/contracts/platform-binding-trigger-spec.js';
+
+interface MockComponentOptions {
+  name: string;
+  type: string;
+  capabilities?: ComponentCapabilities;
+  contextOverrides?: Partial<ComponentContext>;
+  onSynth?: () => void;
+  constructs?: Record<string, Construct>;
+}
+
+export class MockComponent extends Construct implements IComponent {
+  readonly spec: ComponentSpec;
+  readonly context: ComponentContext;
+  private capabilities: ComponentCapabilities;
+  private onSynth?: () => void;
+  private constructs: Record<string, Construct>;
+
+  constructor(scope: Construct, id: string, options: MockComponentOptions) {
+    super(scope, id);
+    this.spec = {
+      name: options.name,
+      type: options.type,
+      config: {},
+      binds: []
+    };
+    this.context = {
+      serviceName: 'test-service',
+      environment: 'test',
+      complianceFramework: 'commercial',
+      scope,
+      ...options.contextOverrides
+    };
+    this.capabilities = options.capabilities ?? {};
+    this.onSynth = options.onSynth;
+    this.constructs = options.constructs ?? {};
+  }
+
+  synth(): void {
+    this.onSynth?.();
+  }
+
+  getCapabilities(): ComponentCapabilities {
+    return this.capabilities;
+  }
+
+  getType(): string {
+    return this.spec.type;
+  }
+
+  getName(): string {
+    return this.spec.name;
+  }
+
+  getId(): string {
+    return this.node.id;
+  }
+
+  getServiceName(): string {
+    return this.context.serviceName;
+  }
+
+  getCapabilityData(): any {
+    return this.capabilities;
+  }
+
+  getConstruct(handle: string): Construct | undefined {
+    return this.constructs[handle];
+  }
+
+  _getSecurityGroupHandle(): any {
+    return undefined;
+  }
+}
+
+export const createTestStack = () => {
+  const app = new cdk.App();
+  return new cdk.Stack(app, 'TestStack');
+};
+
+export const createTestManifest = (components: Array<Partial<ComponentSpec>>): any => ({
+  service: 'test-service',
+  owner: 'platform-team',
+  complianceFramework: 'commercial',
+  environment: 'test',
+  components
+});
+
+export const createMockBindingResult = (
+  overrides: Partial<EnhancedBindingResult> = {}
+): EnhancedBindingResult => ({
+  environmentVariables: {},
+  iamPolicies: [],
+  securityGroupRules: [],
+  compliance: {
+    status: 'compliant',
+    framework: 'commercial',
+    actionsTaken: []
+  },
+  ...overrides
+});
+
+export const createTestLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+});
+
+export const createTestResolverEngine = (options: { binderRegistry: UnifiedBinderRegistry; logger?: any }) => {
+  return new ResolverEngine({
+    logger: options.logger ?? createTestLogger(),
+    binderRegistry: options.binderRegistry
+  });
+};
+
+export const createMockBinderStrategy = (options: {
+  supportedCapabilities: string[];
+  canHandle?: (sourceType: string, capability: string) => boolean;
+  bind: (context: BindingContext) => Promise<EnhancedBindingResult>;
+  compatibility?: CompatibilityEntry[];
+}): IUnifiedBinderStrategy => ({
+  supportedCapabilities: options.supportedCapabilities,
+  canHandle: options.canHandle ?? (() => true),
+  bind: options.bind,
+  getCompatibilityMatrix: () => options.compatibility ?? []
+});
+
+export const createMockBinderRegistry = (strategies: IUnifiedBinderStrategy[]): UnifiedBinderRegistry =>
+  new UnifiedBinderRegistry(strategies);
+
+export const createOutputsMap = (components: IComponent[], constructs?: Record<string, Construct>) => {
+  const outputsMap = new Map<string, any>();
+  for (const component of components) {
+    outputsMap.set(component.spec.name, {
+      construct: constructs?.[component.spec.name],
+      capabilities: component.getCapabilities(),
+      component
+    });
+  }
+  return outputsMap;
+};

--- a/packages/core/src/resolver/resolver-engine.ts
+++ b/packages/core/src/resolver/resolver-engine.ts
@@ -207,6 +207,10 @@ export class ResolverEngine {
     this.dependencies.logger.debug('Phase 3: Component Binding');
 
     const bindings: Array<{ source: string; target: string; capability: string; result: EnhancedBindingResult }> = [];
+    const envVarRegistry = new Map<string, { value: string; source: string; target: string }>();
+    const iamPolicyRegistry = new Map<string, { actions: Set<string>; effects: Set<string> }>();
+
+    this.validateBindingGraph(components, outputsMap);
 
     // AC-RS3.1: Iterate through components that have binds directive
     for (const component of components) {
@@ -269,6 +273,26 @@ export class ResolverEngine {
             result: result
           });
 
+          this.trackEnvironmentVariables(
+            result.environmentVariables,
+            {
+              source: component.spec.name,
+              target: target.component.spec.name,
+              capability: validatedDirective.capability
+            },
+            envVarRegistry
+          );
+
+          this.trackIamPolicies(
+            result.iamPolicies,
+            {
+              source: component.spec.name,
+              target: target.component.spec.name,
+              capability: validatedDirective.capability
+            },
+            iamPolicyRegistry
+          );
+
           this.dependencies.logger.debug(
             `Bound ${component.spec.name} -> ${target.component.spec.name} (${validatedDirective.capability}) ` +
             `[Compliance: ${result.compliance.status}]`
@@ -286,6 +310,131 @@ export class ResolverEngine {
 
     this.dependencies.logger.info(`Applied ${bindings.length} component bindings`);
     return bindings;
+  }
+
+  private validateBindingGraph(components: IComponent[], outputsMap: Map<string, any>): void {
+    const adjacency = new Map<string, string[]>();
+
+    for (const component of components) {
+      const edges: string[] = [];
+      const binds = component.spec.binds;
+      if (binds && Array.isArray(binds)) {
+        for (const bind of binds) {
+          const target = this.resolveTarget(bind, outputsMap);
+          if (!target) {
+            throw new Error(`Cannot resolve binding target for directive: ${JSON.stringify(bind)}`);
+          }
+          edges.push(target.component.spec.name);
+        }
+      }
+      adjacency.set(component.spec.name, edges);
+    }
+
+    const visited = new Set<string>();
+    const inStack = new Set<string>();
+    const path: string[] = [];
+
+    const visit = (node: string) => {
+      visited.add(node);
+      inStack.add(node);
+      path.push(node);
+
+      for (const neighbor of adjacency.get(node) ?? []) {
+        if (!visited.has(neighbor)) {
+          visit(neighbor);
+        } else if (inStack.has(neighbor)) {
+          const cycleStartIndex = path.indexOf(neighbor);
+          const cyclePath = path.slice(cycleStartIndex).concat(neighbor);
+          throw new Error(`Circular binding dependency detected: ${cyclePath.join(' -> ')}`);
+        }
+      }
+
+      path.pop();
+      inStack.delete(node);
+    };
+
+    for (const node of adjacency.keys()) {
+      if (!visited.has(node)) {
+        visit(node);
+      }
+    }
+  }
+
+  private trackEnvironmentVariables(
+    environmentVariables: Record<string, string>,
+    binding: { source: string; target: string; capability: string },
+    registry: Map<string, { value: string; source: string; target: string }>
+  ): void {
+    for (const [key, value] of Object.entries(environmentVariables ?? {})) {
+      if (registry.has(key)) {
+        const existing = registry.get(key)!;
+        if (existing.value !== value) {
+          this.dependencies.logger.warn(
+            `Environment variable conflict for ${key}: ` +
+            `${existing.source} -> ${existing.target} (${existing.value}) ` +
+            `overwritten by ${binding.source} -> ${binding.target} (${value}).`
+          );
+        }
+      }
+
+      registry.set(key, { value, source: binding.source, target: binding.target });
+    }
+  }
+
+  private trackIamPolicies(
+    iamPolicies: Array<{ statement: any }>,
+    binding: { source: string; target: string; capability: string },
+    registry: Map<string, { actions: Set<string>; effects: Set<string> }>
+  ): void {
+    for (const policy of iamPolicies ?? []) {
+      const statementJson = policy.statement.toStatementJson();
+      const actions = this.normalizePolicyField(statementJson.Action ?? []);
+      const resources = this.normalizePolicyField(statementJson.Resource ?? []);
+      const effect = statementJson.Effect ?? 'Allow';
+
+      for (const resource of resources) {
+        if (!registry.has(resource)) {
+          registry.set(resource, { actions: new Set(), effects: new Set() });
+        }
+
+        const entry = registry.get(resource)!;
+        if (entry.effects.size > 0 && !entry.effects.has(effect)) {
+          throw new Error(
+            `Conflicting IAM policy effects for ${resource}: ` +
+            `${Array.from(entry.effects).join(', ')} vs ${effect} ` +
+            `(${binding.source} -> ${binding.target})`
+          );
+        }
+
+        entry.effects.add(effect);
+
+        for (const action of actions) {
+          if (!entry.actions.has(action)) {
+            if (entry.actions.size > 0) {
+              this.dependencies.logger.info(
+                `Merged IAM actions for ${resource}: added ${action} ` +
+                `from ${binding.source} -> ${binding.target}.`
+              );
+            }
+            entry.actions.add(action);
+          }
+
+          if (action === '*' || action.endsWith(':*')) {
+            this.dependencies.logger.warn(
+              `Over-privileging detected for ${resource}: action ${action} ` +
+              `from ${binding.source} -> ${binding.target}.`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  private normalizePolicyField(value: string | string[]): string[] {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    return value ? [value] : [];
   }
 
   /**

--- a/packages/core/src/resolver/security-group-rule-post-processor.ts
+++ b/packages/core/src/resolver/security-group-rule-post-processor.ts
@@ -244,6 +244,8 @@ export class SecurityGroupRulePostProcessor {
     rules: TrackedSecurityGroupRule[]
   ): SecurityGroupRuleGroup[] {
     const groupsMap = new Map<string, SecurityGroupRuleGroup>();
+    const ruleDedupKeys = new Map<string, Set<string>>();
+    const ruleConflictKeys = new Map<string, Map<string, string>>();
     
     for (const rule of rules) {
       const targetId = rule.targetSecurityGroupId;
@@ -253,13 +255,54 @@ export class SecurityGroupRulePostProcessor {
           targetSecurityGroupId: targetId,
           rules: []
         });
+        ruleDedupKeys.set(targetId, new Set());
+        ruleConflictKeys.set(targetId, new Map());
       }
       
       const group = groupsMap.get(targetId)!;
+      const dedupeKey = this.buildRuleKey(rule);
+      const conflictKey = this.buildRuleConflictKey(rule);
+      const conflictMap = ruleConflictKeys.get(targetId)!;
+      const existingType = conflictMap.get(conflictKey);
+
+      if (existingType && existingType !== rule.type) {
+        throw new Error(
+          `[SG-PostProcessor] Conflicting security group rules for ${targetId}: ` +
+          `${existingType} vs ${rule.type} (${rule.description})`
+        );
+      }
+      conflictMap.set(conflictKey, rule.type);
+
+      const dedupeSet = ruleDedupKeys.get(targetId)!;
+      if (dedupeSet.has(dedupeKey)) {
+        continue;
+      }
+      dedupeSet.add(dedupeKey);
       group.rules.push(rule);
     }
     
     return Array.from(groupsMap.values());
+  }
+
+  private static buildRuleKey(rule: TrackedSecurityGroupRule): string {
+    return [
+      rule.type,
+      rule.peer.kind,
+      rule.peer.id,
+      rule.port.from,
+      rule.port.to,
+      rule.port.protocol
+    ].join('|');
+  }
+
+  private static buildRuleConflictKey(rule: TrackedSecurityGroupRule): string {
+    return [
+      rule.peer.kind,
+      rule.peer.id,
+      rule.port.from,
+      rule.port.to,
+      rule.port.protocol
+    ].join('|');
   }
   
   /**
@@ -400,4 +443,3 @@ export class SecurityGroupRulePostProcessor {
     return `${rule.sourceComponent}-${rule.targetComponent}-${hash.substring(0, 8)}`;
   }
 }
-

--- a/packages/core/src/services/tests/binding-directive-env-var-collisions.test.ts
+++ b/packages/core/src/services/tests/binding-directive-env-var-collisions.test.ts
@@ -1,0 +1,82 @@
+import { ResolverEngine } from '../../resolver/resolver-engine.js';
+import { UnifiedBinderRegistry } from '../../platform/binders/registry/unified-binder-registry.js';
+import { createOutputsMap, createTestLogger, createTestStack, MockComponent } from '../../resolver/__tests__/test-helpers.js';
+import type { IUnifiedBinderStrategy } from '../../platform/contracts/platform-binding-trigger-spec.js';
+
+const createEnvVarStrategy = (): IUnifiedBinderStrategy => ({
+  supportedCapabilities: ['networking:vpc'],
+  canHandle: () => true,
+  bind: async (context) => ({
+    environmentVariables: context.directive.env ?? {},
+    iamPolicies: [],
+    securityGroupRules: [],
+    compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+  }),
+  getCompatibilityMatrix: () => []
+});
+
+describe('BindingDirective__EnvVarCollisions', () => {
+  it('EnvVarCollisions__SameNameDifferentMeanings__Detected', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const vpcA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const vpcB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = new ResolverEngine({
+      logger,
+      binderRegistry: new UnifiedBinderRegistry([createEnvVarStrategy()])
+    });
+
+    await (resolver as any).bindComponents([source, vpcA, vpcB], createOutputsMap([source, vpcA, vpcB]), {});
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Environment variable conflict for VPC_ID'));
+  });
+
+  it('EnvVarCollisions__NamespacedVariables__NoCollision', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const vpcA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const vpcB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_A_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_B_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = new ResolverEngine({
+      logger,
+      binderRegistry: new UnifiedBinderRegistry([createEnvVarStrategy()])
+    });
+
+    await (resolver as any).bindComponents([source, vpcA, vpcB], createOutputsMap([source, vpcA, vpcB]), {});
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('EnvVarCollisions__VariableRegistry__Tracking', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const vpcA = new MockComponent(stack, 'VpcA', { name: 'vpc-a', type: 'vpc' });
+    const vpcB = new MockComponent(stack, 'VpcB', { name: 'vpc-b', type: 'vpc' });
+    source.spec.binds = [
+      { to: 'vpc-a', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-a' } },
+      { to: 'vpc-b', capability: 'networking:vpc', access: 'read', env: { VPC_ID: 'vpc-b' } }
+    ];
+
+    const logger = createTestLogger();
+    const resolver = new ResolverEngine({
+      logger,
+      binderRegistry: new UnifiedBinderRegistry([createEnvVarStrategy()])
+    });
+
+    await (resolver as any).bindComponents([source, vpcA, vpcB], createOutputsMap([source, vpcA, vpcB]), {});
+
+    const warningCalls = (logger.warn as jest.Mock).mock.calls.flat().join(' ');
+    expect(warningCalls).toContain('Environment variable conflict');
+  });
+});

--- a/packages/core/src/services/tests/binding-directive-required-capabilities.test.ts
+++ b/packages/core/src/services/tests/binding-directive-required-capabilities.test.ts
@@ -1,0 +1,69 @@
+import { BindingDirectiveValidator } from '../binding-directive-validator.js';
+import { UnifiedBinderRegistry } from '../../platform/binders/registry/unified-binder-registry.js';
+import type { IUnifiedBinderStrategy } from '../../platform/contracts/platform-binding-trigger-spec.js';
+
+const createStrategy = (capability: string): IUnifiedBinderStrategy => ({
+  supportedCapabilities: [capability],
+  canHandle: () => true,
+  bind: async () => ({
+    environmentVariables: {},
+    iamPolicies: [],
+    securityGroupRules: [],
+    compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+  }),
+  getCompatibilityMatrix: () => []
+});
+
+describe('BindingDirectiveValidator__RequiredCapabilities', () => {
+  it('RequiredCapabilities__MissingCapability__PreSynthesisError', async () => {
+    const registry = new UnifiedBinderRegistry([createStrategy('api:rest')]);
+    const validator = new BindingDirectiveValidator({
+      binderRegistry: registry,
+      complianceFramework: 'commercial'
+    });
+
+    const manifest = {
+      components: [
+        { name: 'lambda', type: 'lambda-api', binds: [{ to: 'missing-api', capability: 'api:rest', access: 'read' }] }
+      ]
+    };
+
+    const errors = await validator.validateBindingDirectives(manifest);
+    expect(errors.some(error => error.message.includes("Target component 'missing-api' not found"))).toBe(true);
+  });
+
+  it('RequiredCapabilities__CapabilityRegistry__Validation', async () => {
+    const registry = new UnifiedBinderRegistry([]);
+    const validator = new BindingDirectiveValidator({
+      binderRegistry: registry,
+      complianceFramework: 'commercial'
+    });
+
+    const manifest = {
+      components: [
+        { name: 'lambda', type: 'lambda-api', binds: [{ to: 'api', capability: 'api:rest', access: 'read' }] },
+        { name: 'api', type: 'api-gateway-rest' }
+      ]
+    };
+
+    const errors = await validator.validateBindingDirectives(manifest);
+    expect(errors.some(error => error.message.includes('No binder found'))).toBe(true);
+  });
+
+  it('RequiredCapabilities__ComponentRequiresVpc__Validation', async () => {
+    const registry = new UnifiedBinderRegistry([createStrategy('networking:vpc')]);
+    const validator = new BindingDirectiveValidator({
+      binderRegistry: registry,
+      complianceFramework: 'commercial'
+    });
+
+    const manifest = {
+      components: [
+        { name: 'rds', type: 'rds-postgres', binds: [{ to: 'vpc', capability: 'networking:vpc', access: 'read' }] }
+      ]
+    };
+
+    const errors = await validator.validateBindingDirectives(manifest);
+    expect(errors.some(error => error.message.includes("Target component 'vpc' not found"))).toBe(true);
+  });
+});

--- a/packages/core/src/services/tests/binding-directive-selector-ambiguity.test.ts
+++ b/packages/core/src/services/tests/binding-directive-selector-ambiguity.test.ts
@@ -1,0 +1,82 @@
+import { ResolverEngine } from '../../resolver/resolver-engine.js';
+import { UnifiedBinderRegistry } from '../../platform/binders/registry/unified-binder-registry.js';
+import type { IUnifiedBinderStrategy } from '../../platform/contracts/platform-binding-trigger-spec.js';
+import { createOutputsMap, createTestLogger, createTestStack, MockComponent } from '../../resolver/__tests__/test-helpers.js';
+
+const createStrategy = (): IUnifiedBinderStrategy => ({
+  supportedCapabilities: ['api:rest'],
+  canHandle: () => true,
+  bind: async () => ({
+    environmentVariables: {},
+    iamPolicies: [],
+    securityGroupRules: [],
+    compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+  }),
+  getCompatibilityMatrix: () => []
+});
+
+describe('BindingDirectiveSelector__Ambiguity', () => {
+  it('SelectorAmbiguity__MultipleMatches__ClearError', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const apiA = new MockComponent(stack, 'ApiA', { name: 'api-a', type: 'api-gateway-rest' });
+    const apiB = new MockComponent(stack, 'ApiB', { name: 'api-b', type: 'api-gateway-rest' });
+    source.spec.binds = [{ select: { type: 'api-gateway-rest' }, capability: 'api:rest', access: 'read' }];
+
+    const resolver = new ResolverEngine({
+      logger: createTestLogger(),
+      binderRegistry: new UnifiedBinderRegistry([createStrategy()])
+    });
+
+    await expect((resolver as any).bindComponents([source, apiA, apiB], createOutputsMap([source, apiA, apiB]), {}))
+      .rejects
+      .toThrow('Ambiguous selector');
+  });
+
+  it('SelectorAmbiguity__LabelDisambiguation__Works', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const apiA = new MockComponent(stack, 'ApiA', { name: 'api-a', type: 'api-gateway-rest' });
+    const apiB = new MockComponent(stack, 'ApiB', { name: 'api-b', type: 'api-gateway-rest' });
+    apiA.spec.labels = { env: 'prod' };
+    apiB.spec.labels = { env: 'staging' };
+    source.spec.binds = [{ select: { type: 'api-gateway-rest', withLabels: { env: 'prod' } }, capability: 'api:rest', access: 'read' }];
+
+    const resolver = new ResolverEngine({
+      logger: createTestLogger(),
+      binderRegistry: new UnifiedBinderRegistry([createStrategy()])
+    });
+
+    await (resolver as any).bindComponents([source, apiA, apiB], createOutputsMap([source, apiA, apiB]), {});
+  });
+
+  it('SelectorAmbiguity__PreValidation__CatchesEarly', async () => {
+    const stack = createTestStack();
+    const source = new MockComponent(stack, 'Lambda', { name: 'lambda', type: 'lambda-api' });
+    const apiA = new MockComponent(stack, 'ApiA', { name: 'api-a', type: 'api-gateway-rest' });
+    const apiB = new MockComponent(stack, 'ApiB', { name: 'api-b', type: 'api-gateway-rest' });
+    source.spec.binds = [{ select: { type: 'api-gateway-rest' }, capability: 'api:rest', access: 'read' }];
+
+    const bindSpy = jest.fn(async () => ({
+      environmentVariables: {},
+      iamPolicies: [],
+      securityGroupRules: [],
+      compliance: { status: 'compliant', framework: 'commercial', actionsTaken: [] }
+    }));
+
+    const resolver = new ResolverEngine({
+      logger: createTestLogger(),
+      binderRegistry: new UnifiedBinderRegistry([{
+        supportedCapabilities: ['api:rest'],
+        canHandle: () => true,
+        bind: bindSpy,
+        getCompatibilityMatrix: () => []
+      }])
+    });
+
+    await expect((resolver as any).bindComponents([source, apiA, apiB], createOutputsMap([source, apiA, apiB]), {}))
+      .rejects
+      .toThrow('Ambiguous selector');
+    expect(bindSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Several new resolver tests were mutating process state and globals which produced flaky tests and leaked state across tests.
- Binding resolution surfaced cycles and missing targets late in the pipeline, causing non-deterministic failures during bind execution.  
- Environment variables and IAM policy statements produced by bindings could silently conflict, overwrite, or over-privilege without clear warnings or failures.  
- Security-group post-processing could create duplicate or contradictory ingress/egress rules when multiple bindings targeted the same security group.

### Description
- Stabilized tests by restoring overridden globals (`global.fetch`), using `child_process.execSync` spies, replacing `@ts-expect-error` with explicit casts, and wrapping `process.chdir` calls in `try/finally` to always reset the working directory.  
- Added `validateBindingGraph`, `trackEnvironmentVariables`, and `trackIamPolicies` to `ResolverEngine` to perform pre-binding cycle detection and to track/emit warnings or errors for env var and IAM conflicts/over-privileging.  
- Enhanced `SecurityGroupRulePostProcessor` with rule deduplication and conflict detection using deterministic rule keys and conflict checks to prevent duplicate or contradictory `ingress`/`egress` rules.  
- Added test infrastructure (`test-helpers.ts`, `test-fixtures.ts`) and a broad suite of unit tests covering binding timing, circular bindings, env var collisions, IAM policy conflicts, SG post-processing timing/deduplication, selector ambiguity, and capability/version handling under `packages/core/src/{resolver,platform,services}/__tests__`.

### Testing
- Added many unit tests under `packages/core/src/resolver/__tests__`, `packages/core/src/platform/{contracts,networking}/__tests__`, and `packages/core/src/services/tests/`, but no CI or automated test suite was executed as part of this change.  
- Updated tests to ensure deterministic cleanup and to avoid leaking global state; these edits improve reliability when the test suite is executed.  
- No automated test run was requested or performed in this PR; therefore there are no passing/failing results to report.  
- Recommended next step: run the full test suite in CI (for example `pnpm test`) to validate behavior across environments before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696114a80ff88333b4abca474b1845c1)