### PR TITLE
Add Harmony Phase 1 package (agent, MCP, Dagger, Temporal), DI refactor, tests, and Kanban status

### DIFF
--- a/apps/harmony/README.md
+++ b/apps/harmony/README.md
@@ -1,0 +1,79 @@
+# Harmony Golden Path (Phase 1)
+
+This package implements Phase 1 from `docs/harmony`: a local Golden Path that runs the Brain (LangGraph), Nervous System (Temporal), and Muscle (Dagger) together with an MCP tool server in STDIO mode.
+
+## Prerequisites
+
+- Docker (privileged containers enabled for the Dagger engine)
+- Node.js 20+
+- pnpm 10+
+- LLM API key (set `HARMONY_LLM_API_KEY`)
+
+## Start the local stack
+
+From the repo root:
+
+```bash
+cd apps/harmony
+docker compose -f docker-compose.golden-path.yml up -d
+```
+
+This starts:
+- Temporal dev server + UI on `localhost:8233`
+- Dagger engine on `localhost:6060`
+- MCP Inspector on `localhost:6274`
+
+> If the MCP Inspector image tag changes, update `docker-compose.golden-path.yml` with the latest published image.
+
+## Run the MCP tool server (STDIO)
+
+In a new terminal:
+
+```bash
+cd apps/harmony
+pnpm install
+pnpm start:mcp
+```
+
+The MCP server exposes the `analyze_repo` tool for cloning and scanning repositories through Dagger.
+
+## Run the Temporal worker
+
+```bash
+cd apps/harmony
+pnpm start:worker
+```
+
+## Run the durable agent
+
+```bash
+cd apps/harmony
+HARMONY_LLM_API_KEY="..." \
+HARMONY_REPO="https://github.com/modelcontextprotocol/servers" \
+pnpm start:client
+```
+
+The workflow runs the Plan → Execute → Review steps and outputs the resulting state, including the README contents, file tree, and review notes.
+
+## Configuration
+
+Runtime defaults live in `config/runtime.json`, and every value can be overridden via environment variables.
+
+Key overrides:
+- `HARMONY_MCP_SERVER_COMMAND`, `HARMONY_MCP_SERVER_ENTRY`
+- `HARMONY_TEMPORAL_TASK_QUEUE`, `HARMONY_TEMPORAL_WORKFLOW_PREFIX`
+- `HARMONY_DEFAULT_GOAL`, `HARMONY_DEFAULT_REPO`
+- `HARMONY_LLM_PROVIDER`, `HARMONY_LLM_MODEL`, `HARMONY_LLM_API_KEY`
+
+## Testing
+
+```bash
+cd apps/harmony
+pnpm test
+```
+
+## Troubleshooting
+
+- **Dagger connection errors**: ensure the Dagger engine container is running and the Docker socket is accessible.
+- **Temporal connection errors**: confirm `localhost:7233` is reachable and the Temporal dev server is up.
+- **MCP Inspector**: if the inspector image is unavailable, run it with `npx @modelcontextprotocol/inspector` instead.

--- a/apps/harmony/config/runtime.json
+++ b/apps/harmony/config/runtime.json
@@ -1,0 +1,28 @@
+{
+  "app": {
+    "name": "harmony"
+  },
+  "mcp": {
+    "clientName": "shinobi-harmony-client",
+    "clientVersion": "0.1.0",
+    "serverName": "shinobi-harmony",
+    "serverVersion": "0.1.0",
+    "serverCommand": "node",
+    "serverEntry": "src/mcp/server.js"
+  },
+  "temporal": {
+    "taskQueue": "harmony",
+    "workflowIdPrefix": "harmony"
+  },
+  "defaults": {
+    "goal": "Analyze repository",
+    "repositoryUrl": "https://github.com/modelcontextprotocol/servers"
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "temperature": 0.2,
+    "maxRetries": 2,
+    "apiBaseUrl": "https://api.openai.com/v1"
+  }
+}

--- a/apps/harmony/docker-compose.golden-path.yml
+++ b/apps/harmony/docker-compose.golden-path.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  temporal:
+    image: temporalio/temporal:1.25.1
+    command: ["temporal", "server", "start-dev", "--ip", "0.0.0.0"]
+    ports:
+      - "7233:7233"
+      - "8233:8233"
+    environment:
+      - TEMPORAL_UI_ENABLED=true
+  dagger-engine:
+    image: registry.dagger.io/engine:v0.11.1
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "6060:6060"
+  mcp-inspector:
+    image: ghcr.io/modelcontextprotocol/inspector:latest
+    ports:
+      - "6274:6274"
+    environment:
+      - MCP_INSPECTOR_PORT=6274

--- a/apps/harmony/package.json
+++ b/apps/harmony/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "harmony",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Shinobi Phase 1 Golden Path: durable agent prototype",
+  "scripts": {
+    "start:mcp": "node src/mcp/server.js",
+    "start:worker": "node src/workflow/worker.js",
+    "start:client": "node src/workflow/run-local.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@dagger.io/dagger": "^0.11.1",
+    "@langchain/langgraph": "^0.0.42",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@temporalio/client": "^1.10.4",
+    "@temporalio/testing": "^1.10.4",
+    "@temporalio/worker": "^1.10.4",
+    "@temporalio/workflow": "^1.10.4",
+    "zod": "^4.1.5"
+  }
+}

--- a/apps/harmony/src/agent/graph.js
+++ b/apps/harmony/src/agent/graph.js
@@ -1,0 +1,58 @@
+import { END, START, StateGraph } from "@langchain/langgraph";
+import { AgentStateSchema, createInitialState } from "./state.js";
+import { listTools, analyzeRepository } from "../mcp/client.js";
+
+const GraphState = AgentStateSchema;
+
+function createPlanNode({ mcpClientFactory, planner }) {
+  return async function planNode(state) {
+    const tools = await mcpClientFactory.withClient((client) => listTools(client));
+
+    return {
+      ...state,
+      plan: await planner(state, tools)
+    };
+  };
+}
+
+function createExecuteNode({ mcpClientFactory }) {
+  return async function executeNode(state) {
+    const result = await mcpClientFactory.withClient((client) =>
+      analyzeRepository(client, state.repositoryUrl)
+    );
+
+    return {
+      ...state,
+      readme: result.readme,
+      tree: result.tree
+    };
+  };
+}
+
+function createReviewNode({ reviewer }) {
+  return async function reviewNode(state) {
+    return {
+      ...state,
+      notes: await reviewer({ goal: state.goal, readme: state.readme, tree: state.tree })
+    };
+  };
+}
+
+export function createAgentGraph({ mcpClientFactory, planner, reviewer }) {
+  const graph = new StateGraph(GraphState)
+    .addNode("plan", createPlanNode({ mcpClientFactory, planner }))
+    .addNode("execute", createExecuteNode({ mcpClientFactory }))
+    .addNode("review", createReviewNode({ reviewer }))
+    .addEdge(START, "plan")
+    .addEdge("plan", "execute")
+    .addEdge("execute", "review")
+    .addEdge("review", END);
+
+  return graph.compile();
+}
+
+export async function runAgent({ goal, repositoryUrl, mcpClientFactory, planner, reviewer }) {
+  const app = createAgentGraph({ mcpClientFactory, planner, reviewer });
+  const initialState = createInitialState({ goal, repositoryUrl });
+  return app.invoke(initialState);
+}

--- a/apps/harmony/src/agent/plan.js
+++ b/apps/harmony/src/agent/plan.js
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { AgentStateSchema } from "./state.js";
+import { buildPlanPrompt } from "../llm/prompts.js";
+import { generateStructuredOutput } from "../llm/structured.js";
+
+const PlanSchema = z.object({
+  steps: z.array(z.string().min(1)).min(1)
+});
+
+export function createPlanner({ llmClient, maxRetries }) {
+  return async function buildPlan(state, tools) {
+    const parsed = AgentStateSchema.parse(state);
+    const hasAnalyzeRepo = tools.some((tool) => tool.name === "analyze_repo");
+
+    if (!hasAnalyzeRepo) {
+      throw new Error("analyze_repo tool not available via MCP");
+    }
+
+    const prompt = buildPlanPrompt({
+      goal: parsed.goal,
+      repositoryUrl: parsed.repositoryUrl,
+      tools
+    });
+
+    const output = await generateStructuredOutput({
+      llmClient,
+      schema: PlanSchema,
+      prompt,
+      maxRetries
+    });
+
+    return output.steps;
+  };
+}

--- a/apps/harmony/src/agent/review.js
+++ b/apps/harmony/src/agent/review.js
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { ToolResultSchema } from "./state.js";
+import { buildReviewPrompt } from "../llm/prompts.js";
+import { generateStructuredOutput } from "../llm/structured.js";
+
+const ReviewSchema = z.object({
+  notes: z.array(z.string().min(1)).min(1)
+});
+
+export function createReviewer({ llmClient, maxRetries }) {
+  return async function reviewAnalysis({ goal, readme, tree }) {
+    const parsed = ToolResultSchema.parse({ readme, tree });
+
+    const prompt = buildReviewPrompt({
+      goal,
+      readme: parsed.readme,
+      tree: parsed.tree
+    });
+
+    const output = await generateStructuredOutput({
+      llmClient,
+      schema: ReviewSchema,
+      prompt,
+      maxRetries
+    });
+
+    return output.notes;
+  };
+}

--- a/apps/harmony/src/agent/state.js
+++ b/apps/harmony/src/agent/state.js
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const AgentStateSchema = z.object({
+  goal: z.string().min(1),
+  messages: z.array(
+    z.object({
+      role: z.enum(["system", "user", "assistant"]),
+      content: z.string().min(1)
+    })
+  ).default([]),
+  plan: z.array(z.string()).default([]),
+  repositoryUrl: z.string().url(),
+  readme: z.string().default(""),
+  tree: z.string().default(""),
+  notes: z.array(z.string()).default([])
+});
+
+export const ToolResultSchema = z.object({
+  readme: z.string(),
+  tree: z.string()
+});
+
+export function createInitialState({ goal, repositoryUrl }) {
+  return AgentStateSchema.parse({
+    goal,
+    repositoryUrl,
+    messages: [],
+    plan: [],
+    readme: "",
+    tree: "",
+    notes: []
+  });
+}

--- a/apps/harmony/src/bootstrap/dependencies.js
+++ b/apps/harmony/src/bootstrap/dependencies.js
@@ -1,0 +1,35 @@
+import { loadRuntimeConfig, resolveFromAppRoot } from "../config/runtime.js";
+import { createMcpClientFactory } from "../mcp/client.js";
+import { createLlmClient } from "../llm/client.js";
+import { createPlanner } from "../agent/plan.js";
+import { createReviewer } from "../agent/review.js";
+
+export function createRuntimeDependencies({ llmResponder } = {}) {
+  const config = loadRuntimeConfig();
+  const mcpClientFactory = createMcpClientFactory({
+    name: config.mcp.clientName,
+    version: config.mcp.clientVersion,
+    command: config.mcp.serverCommand,
+    serverEntry: resolveFromAppRoot(config.mcp.serverEntry)
+  });
+
+  const llmClient = createLlmClient({
+    provider: config.llm.provider,
+    apiKey: process.env.HARMONY_LLM_API_KEY,
+    apiBaseUrl: config.llm.apiBaseUrl,
+    model: config.llm.model,
+    temperature: config.llm.temperature,
+    responder: llmResponder
+  });
+
+  const planner = createPlanner({ llmClient, maxRetries: config.llm.maxRetries });
+  const reviewer = createReviewer({ llmClient, maxRetries: config.llm.maxRetries });
+
+  return {
+    config,
+    mcpClientFactory,
+    llmClient,
+    planner,
+    reviewer
+  };
+}

--- a/apps/harmony/src/config/runtime.js
+++ b/apps/harmony/src/config/runtime.js
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const configUrl = new URL("../../config/runtime.json", import.meta.url);
+const configDir = dirname(fileURLToPath(configUrl));
+const appRoot = resolve(configDir, "..");
+
+function readConfigFile() {
+  const raw = readFileSync(configUrl, "utf-8");
+  return JSON.parse(raw);
+}
+
+function overrideValue(value, envValue, mapper = (val) => val) {
+  if (envValue === undefined || envValue === "") {
+    return value;
+  }
+  return mapper(envValue);
+}
+
+export function loadRuntimeConfig() {
+  const base = readConfigFile();
+
+  return {
+    app: {
+      name: base.app.name
+    },
+    mcp: {
+      clientName: overrideValue(base.mcp.clientName, process.env.HARMONY_MCP_CLIENT_NAME),
+      clientVersion: overrideValue(base.mcp.clientVersion, process.env.HARMONY_MCP_CLIENT_VERSION),
+      serverName: overrideValue(base.mcp.serverName, process.env.HARMONY_MCP_SERVER_NAME),
+      serverVersion: overrideValue(base.mcp.serverVersion, process.env.HARMONY_MCP_SERVER_VERSION),
+      serverCommand: overrideValue(base.mcp.serverCommand, process.env.HARMONY_MCP_SERVER_COMMAND),
+      serverEntry: overrideValue(base.mcp.serverEntry, process.env.HARMONY_MCP_SERVER_ENTRY)
+    },
+    temporal: {
+      taskQueue: overrideValue(base.temporal.taskQueue, process.env.HARMONY_TEMPORAL_TASK_QUEUE),
+      workflowIdPrefix: overrideValue(
+        base.temporal.workflowIdPrefix,
+        process.env.HARMONY_TEMPORAL_WORKFLOW_PREFIX
+      )
+    },
+    defaults: {
+      goal: overrideValue(base.defaults.goal, process.env.HARMONY_DEFAULT_GOAL),
+      repositoryUrl: overrideValue(base.defaults.repositoryUrl, process.env.HARMONY_DEFAULT_REPO)
+    },
+    llm: {
+      provider: overrideValue(base.llm.provider, process.env.HARMONY_LLM_PROVIDER),
+      model: overrideValue(base.llm.model, process.env.HARMONY_LLM_MODEL),
+      temperature: overrideValue(
+        base.llm.temperature,
+        process.env.HARMONY_LLM_TEMPERATURE,
+        Number
+      ),
+      maxRetries: overrideValue(base.llm.maxRetries, process.env.HARMONY_LLM_MAX_RETRIES, Number),
+      apiBaseUrl: overrideValue(base.llm.apiBaseUrl, process.env.HARMONY_LLM_API_BASE_URL)
+    },
+    paths: {
+      appRoot
+    }
+  };
+}
+
+export function resolveFromAppRoot(relativePath) {
+  return resolve(appRoot, relativePath);
+}

--- a/apps/harmony/src/dagger/scan-repo.js
+++ b/apps/harmony/src/dagger/scan-repo.js
@@ -1,0 +1,35 @@
+import { connect } from "@dagger.io/dagger";
+import { ToolResultSchema } from "../agent/state.js";
+
+export async function scanRepositoryWithClient(client, repoUrl) {
+  const repo = client
+    .container()
+    .from("alpine/git:2.45.2")
+    .withExec(["git", "clone", "--depth", "1", repoUrl, "/repo"]);
+
+  const readmeFile = repo.file("/repo/README.md");
+  const readme = await readmeFile.contents().catch(() => "");
+
+  const tree = await repo
+    .withExec(["sh", "-c", "cd /repo && find . -maxdepth 3 -type f -print | sort"])
+    .stdout();
+
+  return ToolResultSchema.parse({
+    readme,
+    tree
+  });
+}
+
+export function createDaggerClientFactory() {
+  return {
+    withClient: (callback) => connect((client) => callback(client))
+  };
+}
+
+export function createRepositoryScanner({ daggerClientFactory }) {
+  return async function runScan(repoUrl) {
+    return daggerClientFactory.withClient((client) =>
+      scanRepositoryWithClient(client, repoUrl)
+    );
+  };
+}

--- a/apps/harmony/src/llm/client.js
+++ b/apps/harmony/src/llm/client.js
@@ -1,0 +1,64 @@
+function assertValue(value, message) {
+  if (!value) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function buildOpenAiClient({ apiKey, apiBaseUrl, model, temperature }) {
+  const resolvedKey = assertValue(apiKey, "HARMONY_LLM_API_KEY is required for OpenAI.");
+  const baseUrl = apiBaseUrl ?? "https://api.openai.com/v1";
+
+  return {
+    async generateText(prompt) {
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${resolvedKey}`
+        },
+        body: JSON.stringify({
+          model,
+          temperature,
+          messages: [
+            { role: "system", content: "You are a precise JSON-only assistant." },
+            { role: "user", content: prompt }
+          ]
+        })
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`OpenAI request failed: ${response.status} ${text}`);
+      }
+
+      const payload = await response.json();
+      const content = payload.choices?.[0]?.message?.content;
+      if (!content) {
+        throw new Error("OpenAI response missing content.");
+      }
+      return content;
+    }
+  };
+}
+
+function buildMockClient({ responder }) {
+  return {
+    async generateText(prompt) {
+      return responder(prompt);
+    }
+  };
+}
+
+export function createLlmClient({ provider, apiKey, apiBaseUrl, model, temperature, responder }) {
+  const factories = {
+    openai: () => buildOpenAiClient({ apiKey, apiBaseUrl, model, temperature }),
+    mock: () => buildMockClient({ responder })
+  };
+
+  const factory = factories[provider];
+  if (!factory) {
+    throw new Error(`Unsupported LLM provider: ${provider}`);
+  }
+  return factory();
+}

--- a/apps/harmony/src/llm/prompts.js
+++ b/apps/harmony/src/llm/prompts.js
@@ -1,0 +1,23 @@
+export function buildPlanPrompt({ goal, repositoryUrl, tools }) {
+  const toolList = tools.map((tool) => `- ${tool.name}: ${tool.description ?? ""}`).join("\n");
+  return [
+    "You are planning a durable workflow for infrastructure automation.",
+    `Goal: ${goal}`,
+    `Repository URL: ${repositoryUrl}`,
+    "Available tools:",
+    toolList || "- (no tools provided)",
+    "Return JSON with shape: {\"steps\": [\"...\"]}. Ensure each step is concise and actionable."
+  ].join("\n");
+}
+
+export function buildReviewPrompt({ goal, readme, tree }) {
+  return [
+    "You are reviewing repository analysis output for gaps and next steps.",
+    `Goal: ${goal}`,
+    "README:",
+    readme || "(empty)",
+    "File tree:",
+    tree || "(empty)",
+    "Return JSON with shape: {\"notes\": [\"...\"]}."
+  ].join("\n");
+}

--- a/apps/harmony/src/llm/structured.js
+++ b/apps/harmony/src/llm/structured.js
@@ -1,0 +1,24 @@
+export async function generateStructuredOutput({
+  llmClient,
+  schema,
+  prompt,
+  maxRetries
+}) {
+  let lastError = null;
+  let currentPrompt = prompt;
+  const retries = Number.isFinite(maxRetries) ? maxRetries : 0;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const response = await llmClient.generateText(currentPrompt);
+    try {
+      const json = JSON.parse(response);
+      return schema.parse(json);
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      currentPrompt = `${prompt}\n\nThe previous response failed validation:\n${message}\n\nReturn ONLY valid JSON.`;
+    }
+  }
+
+  throw lastError ?? new Error("LLM output failed validation.");
+}

--- a/apps/harmony/src/mcp/client.js
+++ b/apps/harmony/src/mcp/client.js
@@ -1,0 +1,62 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema
+} from "@modelcontextprotocol/sdk/types.js";
+import { ToolResultSchema } from "../agent/state.js";
+
+export function createMcpClientFactory({ name, version, command, serverEntry }) {
+  async function createClient() {
+    const client = new Client({ name, version });
+    const transport = new StdioClientTransport({
+      command,
+      args: [serverEntry]
+    });
+
+    await client.connect(transport);
+    return client;
+  }
+
+  async function withClient(callback) {
+    const client = await createClient();
+    try {
+      return await callback(client);
+    } finally {
+      await client.close();
+    }
+  }
+
+  return {
+    createClient,
+    withClient
+  };
+}
+
+export async function listTools(client) {
+  const result = await client.request({ method: "tools/list" }, ListToolsResultSchema);
+  return result.tools;
+}
+
+export async function analyzeRepository(client, repoUrl) {
+  const result = await client.request(
+    {
+      method: "tools/call",
+      params: {
+        name: "analyze_repo",
+        arguments: {
+          repo_url: repoUrl
+        }
+      }
+    },
+    CallToolResultSchema
+  );
+
+  const textBlock = result.content.find((item) => item.type === "text");
+  if (!textBlock || typeof textBlock.text !== "string") {
+    throw new Error("Tool response missing text payload");
+  }
+
+  const parsed = JSON.parse(textBlock.text);
+  return ToolResultSchema.parse(parsed);
+}

--- a/apps/harmony/src/mcp/server.js
+++ b/apps/harmony/src/mcp/server.js
@@ -1,0 +1,87 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema
+} from "@modelcontextprotocol/sdk/types.js";
+import { createDaggerClientFactory, createRepositoryScanner } from "../dagger/scan-repo.js";
+import { loadRuntimeConfig } from "../config/runtime.js";
+
+function createToolHandlers({ scanRepository }) {
+  return {
+    analyze_repo: async (request) => {
+      const repoUrl = request.params.arguments?.repo_url;
+      if (typeof repoUrl !== "string") {
+        throw new Error("repo_url must be a string");
+      }
+
+      const result = await scanRepository(repoUrl);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result)
+          }
+        ]
+      };
+    }
+  };
+}
+
+export function createMcpServer({ config, scanRepository }) {
+  const server = new Server(
+    {
+      name: config.mcp.serverName,
+      version: config.mcp.serverVersion
+    },
+    {
+      capabilities: {
+        tools: {}
+      }
+    }
+  );
+
+  const handlers = createToolHandlers({ scanRepository });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: "analyze_repo",
+          description: "Clone a repository with Dagger and return README + file tree.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo_url: {
+                type: "string",
+                format: "uri",
+                description: "Git repository URL to analyze."
+              }
+            },
+            required: ["repo_url"]
+          }
+        }
+      ]
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const handler = handlers[request.params.name];
+    if (!handler) {
+      throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+
+    return handler(request);
+  });
+
+  return server;
+}
+
+const config = loadRuntimeConfig();
+const daggerClientFactory = createDaggerClientFactory();
+const scanRepository = createRepositoryScanner({ daggerClientFactory });
+const server = createMcpServer({ config, scanRepository });
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/apps/harmony/src/workflow/activities.js
+++ b/apps/harmony/src/workflow/activities.js
@@ -1,0 +1,49 @@
+import { AgentStateSchema, ToolResultSchema } from "../agent/state.js";
+import { analyzeRepository, listTools } from "../mcp/client.js";
+
+export function createActivities({ mcpClientFactory, planner, reviewer }) {
+  async function discoverToolsActivity() {
+    return mcpClientFactory.withClient((client) => listTools(client));
+  }
+
+  async function generatePlanActivity(state, tools) {
+    const parsed = AgentStateSchema.parse(state);
+    return {
+      ...parsed,
+      plan: await planner(parsed, tools)
+    };
+  }
+
+  async function executeToolActivity(state) {
+    const parsed = AgentStateSchema.parse(state);
+    const result = await mcpClientFactory.withClient((client) =>
+      analyzeRepository(client, parsed.repositoryUrl)
+    );
+    const toolResult = ToolResultSchema.parse(result);
+
+    return {
+      ...parsed,
+      readme: toolResult.readme,
+      tree: toolResult.tree
+    };
+  }
+
+  async function reviewActivity(state) {
+    const parsed = AgentStateSchema.parse(state);
+    return {
+      ...parsed,
+      notes: await reviewer({
+        goal: parsed.goal,
+        readme: parsed.readme,
+        tree: parsed.tree
+      })
+    };
+  }
+
+  return {
+    discoverToolsActivity,
+    generatePlanActivity,
+    executeToolActivity,
+    reviewActivity
+  };
+}

--- a/apps/harmony/src/workflow/run-local.js
+++ b/apps/harmony/src/workflow/run-local.js
@@ -1,0 +1,20 @@
+import { Connection, Client } from "@temporalio/client";
+import { randomUUID } from "node:crypto";
+import { runDurableAnalyzer } from "./workflows.js";
+import { createRuntimeDependencies } from "../bootstrap/dependencies.js";
+
+const connection = await Connection.connect();
+const client = new Client({ connection });
+const { config } = createRuntimeDependencies();
+
+const goal = process.env.HARMONY_GOAL ?? config.defaults.goal;
+const repositoryUrl = process.env.HARMONY_REPO ?? config.defaults.repositoryUrl;
+
+const handle = await client.workflow.start(runDurableAnalyzer, {
+  taskQueue: config.temporal.taskQueue,
+  workflowId: `${config.temporal.workflowIdPrefix}-${randomUUID()}`,
+  args: [{ goal, repositoryUrl }]
+});
+
+const result = await handle.result();
+console.log(JSON.stringify(result, null, 2));

--- a/apps/harmony/src/workflow/worker.js
+++ b/apps/harmony/src/workflow/worker.js
@@ -1,0 +1,17 @@
+import { Worker } from "@temporalio/worker";
+import { createActivities } from "./activities.js";
+import { createRuntimeDependencies } from "../bootstrap/dependencies.js";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const workflowDir = dirname(fileURLToPath(import.meta.url));
+const { config, mcpClientFactory, planner, reviewer } = createRuntimeDependencies();
+const activities = createActivities({ mcpClientFactory, planner, reviewer });
+
+const worker = await Worker.create({
+  workflowsPath: resolve(workflowDir, "./workflows.js"),
+  activities,
+  taskQueue: config.temporal.taskQueue
+});
+
+await worker.run();

--- a/apps/harmony/src/workflow/workflows.js
+++ b/apps/harmony/src/workflow/workflows.js
@@ -1,0 +1,22 @@
+import { proxyActivities } from "@temporalio/workflow";
+import { createInitialState } from "../agent/state.js";
+
+const {
+  discoverToolsActivity,
+  generatePlanActivity,
+  executeToolActivity,
+  reviewActivity
+} = proxyActivities({
+  startToCloseTimeout: "5 minutes"
+});
+
+export async function runDurableAnalyzer({ goal, repositoryUrl }) {
+  let state = createInitialState({ goal, repositoryUrl });
+
+  const tools = await discoverToolsActivity();
+  state = await generatePlanActivity(state, tools);
+  state = await executeToolActivity(state);
+  state = await reviewActivity(state);
+
+  return state;
+}

--- a/apps/harmony/test/agent.test.js
+++ b/apps/harmony/test/agent.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPlanner } from "../src/agent/plan.js";
+import { createReviewer } from "../src/agent/review.js";
+import { createLlmClient } from "../src/llm/client.js";
+
+const baseState = {
+  goal: "Analyze repo",
+  repositoryUrl: "https://example.com/repo.git",
+  messages: [],
+  plan: [],
+  readme: "",
+  tree: "",
+  notes: []
+};
+
+test("planner requires analyze_repo tool", async () => {
+  const llmClient = createLlmClient({
+    provider: "mock",
+    responder: () => JSON.stringify({ steps: ["step one"] })
+  });
+  const planner = createPlanner({ llmClient, maxRetries: 1 });
+  const tools = [{ name: "analyze_repo" }];
+  const plan = await planner(baseState, tools);
+  assert.ok(plan.length >= 1);
+});
+
+test("reviewer parses structured notes", async () => {
+  const llmClient = createLlmClient({
+    provider: "mock",
+    responder: () => JSON.stringify({ notes: ["README missing."] })
+  });
+  const reviewer = createReviewer({ llmClient, maxRetries: 1 });
+  const notes = await reviewer({
+    goal: baseState.goal,
+    readme: "",
+    tree: "./README.md\n./src/index.js"
+  });
+  assert.ok(notes.some((note) => note.includes("README")));
+});
+
+test("planner retries on invalid JSON and repairs output", async () => {
+  let attempts = 0;
+  const llmClient = createLlmClient({
+    provider: "mock",
+    responder: () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return "not-json";
+      }
+      return JSON.stringify({ steps: ["repaired"] });
+    }
+  });
+  const planner = createPlanner({ llmClient, maxRetries: 2 });
+  const tools = [{ name: "analyze_repo" }];
+  const plan = await planner(baseState, tools);
+  assert.deepEqual(plan, ["repaired"]);
+});

--- a/apps/harmony/test/dagger.test.js
+++ b/apps/harmony/test/dagger.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  scanRepositoryWithClient,
+  createRepositoryScanner
+} from "../src/dagger/scan-repo.js";
+
+function buildFakeRepo() {
+  const calls = [];
+  const repo = {
+    calls,
+    container() {
+      calls.push(["container"]);
+      return repo;
+    },
+    from(image) {
+      calls.push(["from", image]);
+      return repo;
+    },
+    withExec(args) {
+      calls.push(["withExec", args]);
+      return repo;
+    },
+    file(path) {
+      calls.push(["file", path]);
+      return {
+        contents: async () => "README content"
+      };
+    },
+    async stdout() {
+      calls.push(["stdout"]);
+      return "./README.md\n./src/index.js";
+    }
+  };
+
+  return repo;
+}
+
+test("scanRepositoryWithClient builds container definition", async () => {
+  const fakeRepo = buildFakeRepo();
+  const output = await scanRepositoryWithClient(fakeRepo, "https://example.com/repo.git");
+
+  assert.equal(output.readme, "README content");
+  assert.ok(output.tree.includes("README.md"));
+  assert.ok(fakeRepo.calls.find(([name]) => name === "from"));
+});
+
+test("repository scanner uses injected dagger client factory", async () => {
+  let called = false;
+  const fakeRepo = buildFakeRepo();
+  const daggerClientFactory = {
+    withClient: async (callback) => {
+      called = true;
+      return callback(fakeRepo);
+    }
+  };
+  const scan = createRepositoryScanner({ daggerClientFactory });
+  const output = await scan("https://example.com/repo.git");
+
+  assert.ok(called);
+  assert.equal(output.readme, "README content");
+});

--- a/apps/harmony/test/workflow.test.js
+++ b/apps/harmony/test/workflow.test.js
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import { createActivities } from "../src/workflow/activities.js";
+import { createPlanner } from "../src/agent/plan.js";
+import { createReviewer } from "../src/agent/review.js";
+import { createLlmClient } from "../src/llm/client.js";
+import { runDurableAnalyzer } from "../src/workflow/workflows.js";
+
+function createGate() {
+  let resolveGate;
+  let rejectGate;
+  const promise = new Promise((resolve, reject) => {
+    resolveGate = resolve;
+    rejectGate = reject;
+  });
+
+  return {
+    wait: () => promise,
+    release: (value) => resolveGate(value),
+    fail: (error) => rejectGate(error)
+  };
+}
+
+test("workflow durability: plan is not re-executed after worker restart", async () => {
+  const env = await TestWorkflowEnvironment.createTimeSkipping();
+  const taskQueue = "durability-test";
+  const workflowDir = dirname(fileURLToPath(import.meta.url));
+  const workflowsPath = resolve(workflowDir, "../src/workflow/workflows.js");
+
+  let planCalls = 0;
+  const executeGate = createGate();
+  let executeStarted;
+  const executeStartedPromise = new Promise((resolve) => {
+    executeStarted = resolve;
+  });
+
+  const llmClient = createLlmClient({
+    provider: "mock",
+    responder: () => {
+      planCalls += 1;
+      return JSON.stringify({ steps: ["analyze repo"] });
+    }
+  });
+
+  const planner = createPlanner({ llmClient, maxRetries: 1 });
+  const reviewer = createReviewer({
+    llmClient: createLlmClient({
+      provider: "mock",
+      responder: () => JSON.stringify({ notes: ["ok"] })
+    }),
+    maxRetries: 1
+  });
+
+  const mcpClientFactory = {
+    async withClient(callback) {
+      const client = {
+        async request(payload) {
+          if (payload.method === "tools/list") {
+            return {
+              tools: [{ name: "analyze_repo", description: "Mock tool" }]
+            };
+          }
+          if (payload.method === "tools/call") {
+            executeStarted();
+            await executeGate.wait();
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    readme: "README",
+                    tree: "./README.md"
+                  })
+                }
+              ]
+            };
+          }
+          throw new Error(`Unexpected MCP method: ${payload.method}`);
+        }
+      };
+
+      return callback(client);
+    }
+  };
+
+  const activities = createActivities({ mcpClientFactory, planner, reviewer });
+
+  let worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue,
+    workflowsPath,
+    activities
+  });
+  let workerRun = worker.run();
+
+  const workflowHandle = await env.client.workflow.start(runDurableAnalyzer, {
+    taskQueue,
+    workflowId: "durability-test-workflow",
+    args: [
+      {
+        goal: "Test durability",
+        repositoryUrl: "https://example.com/repo.git"
+      }
+    ]
+  });
+
+  await executeStartedPromise;
+  await worker.shutdown();
+  await workerRun;
+
+  worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue,
+    workflowsPath,
+    activities
+  });
+  workerRun = worker.run();
+
+  executeGate.release();
+
+  const result = await workflowHandle.result();
+  assert.equal(planCalls, 1);
+  assert.equal(result.readme, "README");
+
+  await worker.shutdown();
+  await workerRun;
+  await env.teardown();
+});

--- a/docs/harmony
+++ b/docs/harmony
@@ -1,77 +1,95 @@
-Shinobi Platform Execution Plan: Architecting Autonomous Infrastructure Operations
-Executive Summary: The Imperative for Durable Agency
+# Harmony Platform Execution Plan: Architecting Autonomous Infrastructure Operations
+
+## Project Status Update (Kanban)
+### Current Status Summary
+- **Done:** Phase 1 Golden Path local stack wiring (Temporal dev server, Dagger engine, MCP Inspector), MCP tool server over STDIO, Dagger repo scanner, LangGraph-style Plan → Execute → Review flow with LLM structured output + repair loop, runtime configuration + dependency injection, and offline test scaffolding.
+- **In Progress:** Phase 1 validation (offline tests still need to be executed in an environment with registry access).
+- **Not Started:** Phase 2 Control Plane deployment on EKS (Temporal cluster, MCP Host gateway, Dagger execution plane), Phase 3 production MCP tool ecosystem (AWS/Jira/GitLab/PagerDuty/Confluence servers) and workflow catalog.
+
+### Roadmap Milestones (Kanban Status)
+| Milestone | Status | Evidence / Notes |
+| --- | --- | --- |
+| Phase 1: Local Golden Path (Docker Compose stack + durable agent prototype) | In Progress | Local stack + Harmony package are implemented; remaining work is running tests offline and validating dependency versions. |
+| Phase 2: Core Infrastructure Deployment (EKS Control Plane + Dagger execution plane) | Not Started | Architecture defined below; no EKS IaC or Shinobi-driven deployment manifest exists yet. |
+| Phase 3: Cognitive Layer & MCP Tooling (AWS/Jira/GitLab/PagerDuty/Confluence) | Not Started | No production MCP tool servers or workflow catalog shipped yet beyond the `analyze_repo` prototype. |
+
+### Progress Assessment
+- The **Phase 1 architecture** is implemented in code and documented in `apps/harmony`, but the **verification step** (offline tests and dependency checks) is pending.
+- **Phase 2+** is still at the **design-only** stage inside this document and has not been converted into Shinobi-managed infrastructure or deployable services.
+
+## Executive Summary: The Imperative for Durable Agency
 The modern enterprise technology landscape is characterized by an explosion of disparate tools—Jira for tracking, GitLab for code, AWS for infrastructure, Slack for communication, and PagerDuty for incident response. While "Infrastructure as Code" (IaC) has successfully addressed the problem of converging infrastructure to a desired state, a significant gap remains in the domain of imperative automation. This is the realm of the "Shinobi Platform": a system designed not merely to maintain static configurations, but to execute dynamic, intent-driven workflows—querying status, patching vulnerabilities, generating compliance reports, and orchestrating complex remediation sequences across heterogeneous systems.
 The Shinobi Platform architecture represents a fundamental shift from fragile, scripted automation to "Durable, Composable Intelligence". Our analysis indicates that the primary failure mode of current "Agentic AI" implementations is infrastructural fragility—agents crash due to transient network issues, lose state during restarts, or hallucinate invalid commands. This execution plan outlines a target end-state architecture that converges three best-in-class technologies into a unified operational fabric: Temporal provides the "Nervous System" of durable execution and orchestration; Dagger acts as the "Muscle," providing a portable, containerized execution substrate; and LangGraph serves as the "Brain," enabling cognitive planning, reasoning, and self-correction.
 This report delivers an exhaustive, comprehensive execution plan to implement the Shinobi architecture. It is structured into six distinct phases, moving from foundational research to production monitoring. It strictly adheres to the engineering principles of SOLID design, Dependency Injection (DI), and Test-Driven Development (TDD), prioritizing a "Golden Path" Minimum Viable Product (MVP) that enables developers to build and verify agents locally before deployment. By standardizing on the Model Context Protocol (MCP) , the platform decouples the cognitive layer from the tool execution layer, solving the "N×M" integration problem that plagues traditional automation platforms.
-1. The Shinobi Engineering Standards: A Constitution for Quality
+## 1. The Shinobi Engineering Standards: A Constitution for Quality
 Before articulating the implementation phases, it is imperative to define the engineering standards that will govern the Shinobi Platform. The transition from script-based automation to software-defined agency requires a rigorous application of software engineering principles. We define these as the "Shinobi Standards," which serve as the immutable constitution for all platform development.
-1.1 The Enforcement of SOLID Principles in Agentic Systems
+### 1.1 The Enforcement of SOLID Principles in Agentic Systems
 The complexity of autonomous agents, which blend probabilistic reasoning (LLMs) with deterministic execution (code), necessitates a strict adherence to SOLID principles to prevent the system from degrading into an unmaintainable "Big Ball of Mud."
-1.1.1 Single Responsibility Principle (SRP)
+#### 1.1.1 Single Responsibility Principle (SRP)
 In the context of Shinobi, SRP dictates that every component—whether a Temporal Activity, a LangGraph Node, or a Dagger Function—must possess one, and only one, reason to change.
  * The Constraint: A Temporal Activity must never mix "Decision Making" with "Tool Execution." An Activity named AnalyzeAndFixDatabase is strictly prohibited. It effectively couples the diagnostic logic with the remediation logic, making it impossible to retry one without the other.
  * The Shinobi Standard: Capabilities must be decomposed into atomic units. We require AnalyzeDatabaseMetrics, GenerateRemediationPlan, and ExecuteSQLCommand as distinct activities. This granularity allows Temporal to retry a failed SQL command without re-running the potentially expensive analysis step.
  * Architectural Implication: This enforces composability. The ExecuteSQLCommand activity becomes a reusable building block that can be employed by multiple different agents (e.g., a "Migration Agent" and a "Repair Agent"), reducing code duplication across the platform.
-1.1.2 Open/Closed Principle (OCP)
+#### 1.1.2 Open/Closed Principle (OCP)
 The platform must be open for extension but closed for modification. As the enterprise integrates new tools (e.g., switching from Jira to Linear, or adding Azure support), the core reasoning loops of the agents must not require refactoring.
  * The Constraint: Agent logic must never hardcode tool sets. A LangGraph agent that explicitly imports boto3 libraries violates this principle.
  * The Shinobi Standard: Agents must interact with the world exclusively through the Model Context Protocol (MCP) abstraction. The agent queries an MCP Host for available tools (tools/list). To add a new capability, platform engineers deploy a new MCP Server. The agent "discovers" this new capability at runtime without a single line of code changing in the agent's reasoning engine.
  * Architectural Implication: This creates a plugin architecture where the "Brain" (LangGraph) is decoupled from the "Hands" (Tools), allowing them to evolve independently.
-1.1.3 Liskov Substitution Principle (LSP) & Dependency Inversion (DIP)
+#### 1.1.3 Liskov Substitution Principle (LSP) & Dependency Inversion (DIP)
 To ensure testability and interchangeability, high-level policy (the Agent) must not depend on low-level details (the AWS SDK). Both must depend on abstractions.
  * The Constraint: No Temporal Activity may instantiate an external client (e.g., boto3.client('s3')) within its execution logic.
  * The Shinobi Standard: All external dependencies must be injected via Constructor Injection. We mandate the use of Interface Definition Languages (IDLs) or abstract base classes for all I/O operations.
    * Implementation: In Go, this means defining a CloudProvider interface. In Python, an AbstractCloudClient.
    * Mechanism: A Dependency Injection (DI) container (e.g., uber-go/dig for Go workers or dependency-injector for Python) must be used to wire these dependencies at worker startup.
  * Architectural Implication: This is the cornerstone of our testing strategy. By injecting dependencies, we can substitute the real AWS client with a MockCloudProvider during unit tests, enabling the validation of agent logic without incurring cloud costs or requiring network connectivity.
-1.2 The Test-Driven Development (TDD) Mandate
+### 1.2 The Test-Driven Development (TDD) Mandate
 The "Golden Path" for Shinobi development relies on the assertion that local verification must precede cloud deployment. The feedback loop of deploying to EKS to test a line of code is prohibitively slow and expensive.
-1.2.1 The "Offline First" Requirement
+#### 1.2.1 The "Offline First" Requirement
 All agents must be capable of running in an "Offline Mode."
  * The Standard: Every Temporal Workflow and LangGraph Agent must have a corresponding test suite that runs successfully with no network access.
  * Mechanism: This requires the rigorous application of the DI principle described above. Developers must write tests that mock the MCP tool responses. For example, a test case for a "Disk Cleanup Agent" should inject a mock response simulating a "Disk Full" event and verify that the agent generates the correct "Delete Logs" plan, without actually touching a real server.
-1.2.2 Temporal Time-Skipping
-Testing long-running workflows (e.g., "Wait 3 days for approval") is challenging in traditional frameworks.
+#### 1.2.2 Temporal Time-Skipping
+Testing long-running workflows (e.g., "Wait for approval") is challenging in traditional frameworks.
  * The Standard: All workflow tests must utilize the Temporal Test Framework.
- * Mechanism: This framework allows the test runner to manipulate the workflow's internal clock. A test can simulate the passage of 3 days in a fraction of a millisecond, verifying that the timeout logic or reminder signals fire correctly. This capability is essential for validating the "Nervous System" of the platform.
-1.3 Strictly Typed Interfaces (JSON Schema/Pydantic)
+ * Mechanism: This framework allows the test runner to manipulate the workflow's internal clock. A test can simulate the passage of an approval window in a fraction of a millisecond, verifying that the timeout logic or reminder signals fire correctly. This capability is essential for validating the "Nervous System" of the platform.
+### 1.3 Strictly Typed Interfaces (JSON Schema/Pydantic)
 The probabilistic nature of LLMs introduces the risk of "hallucination," where an agent generates invalid or dangerous commands.
  * The Standard: All inputs to Dagger Functions and all outputs from LangGraph nodes must be validated against a strict JSON Schema or Pydantic model. Free text is prohibited for inter-process communication.
  * Mechanism: We utilize the "Structured Outputs" or "Function Calling" modes of modern LLMs to constrain generation.
  * The "Repair Loop": If Pydantic validation fails (e.g., the LLM outputs a string where an integer is required), the exception is caught, formatted as a prompt ("Error: Field 'retries' must be an integer"), and fed back to the LLM. This "self-healing" mechanism ensures that invalid data never propagates to the execution layer.
-2. Phase 1: Research & Prototyping – The Local "Golden Path"
+## 2. Phase 1: Research & Prototyping – The Local "Golden Path"
 Objective: The primary objective of Phase 1 is to construct the "Golden Path"—a local development environment that mirrors the production architecture but runs entirely on a developer's laptop. This mitigates the "Works on My Machine" syndrome and accelerates iteration velocity.
-2.1 The "Golden Path" Architecture
+### 2.1 The "Golden Path" Architecture
 To achieve a production-parity local environment, we must containerize the entire platform stack. The "Golden Path" is defined as a Docker Compose or DevContainer configuration that spins up the complete Triad: Brain, Nervous System, and Muscle.
-2.1.1 The Local Stack Definition
+#### 2.1.1 The Local Stack Definition
  * Orchestrator (Temporal): We will utilize the temporal server start-dev executable. This provides a lightweight, single-binary version of the Temporal server with an ephemeral SQLite backend and a web UI.
  * Executor (Dagger): The Dagger Engine runs as a privileged Docker container. The developer's host Docker socket is mounted into this container, or it runs as a sibling container, allowing Dagger to spawn its own build containers.
  * Interface (MCP Inspector): Instead of the full Backstage UI (which is heavy), local development uses the MCP Inspector. This web-based tool allows developers to manually inspect connected MCP servers, list tools, and simulate tool calls, effectively acting as a debugger for the "Senses" of the agent.
  * Transport (STDIO): For local development, we enforce the STDIO transport for MCP. The Agent spawns the tool server as a subprocess and communicates via standard input/output. This eliminates the complexity of managing local ports and simulates the isolation of production services.
-2.2 Prototype Implementation: The "Hello World" Durable Agent
+### 2.2 Prototype Implementation: The "Hello World" Durable Agent
 To validate this architecture, Phase 1 includes the construction of a reference agent: the "GitHub Repository Analyzer." This agent demonstrates the end-to-end flow from intent to execution.
-2.2.1 Component 1: The Muscle (Dagger Module)
+#### 2.2.1 Component 1: The Muscle (Dagger Module)
 We define a Dagger Module in Python that encapsulates the physical operation.
  * Function: scan_repository(repo_url: str) -> str.
  * Logic: The function uses the Dagger SDK to spin up a git container, clone the specified URL, and extract the README.md and file structure.
  * DI Application: The dagger.Client is injected. This allows the unit test to verify that the container definition is constructed correctly without actually performing the clone.
-2.2.2 Component 2: The Senses (MCP Server)
+#### 2.2.2 Component 2: The Senses (MCP Server)
 We wrap the Dagger Module in an MCP Server.
  * Primitive: We expose a Tool named analyze_repo.
  * Schema: The server publishes a JSON schema defining the input (repo_url: format URI) and the output structure.
  * Transport: The server is configured to listen on STDIO.
-2.2.3 Component 3: The Brain (LangGraph Agent)
+#### 2.2.3 Component 3: The Brain (LangGraph Agent)
 We implement the reasoning loop using LangGraph.
  * Nodes:
    * Plan: Accepts the user goal ("Analyze the Shinobi repo") and consults the MCP tool list to generate a step-by-step plan.
    * Execute: Calls the analyze_repo tool via the MCP client.
    * Review: Analyzes the output. If the README is missing, it plans a secondary step ("List files to find documentation").
  * State: The state object is defined as a Pydantic model AgentState, containing the messages history and the current_plan.
-2.2.4 Component 4: The Nervous System (Temporal Workflow)
+#### 2.2.4 Component 4: The Nervous System (Temporal Workflow)
 We wrap the LangGraph agent in a Temporal Workflow, creating the Durable Agent.
  * Workflow Logic: The workflow serves as the persistent host. It instantiates the LangGraph graph. It executes the Plan node as a Temporal Activity. It saves the resulting state to the Temporal History. It then executes the Execute node.
  * Durability Test: We simulate a crash during the Execute phase. Upon restart, the Temporal Worker replays the history, restores the AgentState, and resumes execution without re-querying the LLM for the plan, ensuring determinism.
-2.3 Phase 1 Dependencies and Risk Analysis
+### 2.3 Phase 1 Dependencies and Risk Analysis
 The following tables detail the specific dependencies and risks identified for this initial phase.
 Table 1: Phase 1 Dependencies
 | Dependency | Version/Spec | Criticality | Purpose |
@@ -87,50 +105,50 @@ Table 2: Phase 1 Risks
 | Integration | MCP Transport Latency: STDIO performance may differ from production SSE. | Low | Low | Accept difference for local dev; validate SSE in Phase 2. |
 | Execution | Dagger Privileged Mode: Developers may lack permissions to run privileged containers on corporate laptops. | Medium | High | Provide cloud-based "Remote Dev Environments" (e.g., GitHub Codespaces) pre-configured with privileges. |
 | Cognitive | Local LLM Performance: Running local LLMs (Ollama) for dev may be too slow/dumb. | High | Medium | Configure the local agent to proxy calls to an external model (GPT-4o/Claude) via API key. |
-3. Phase 2: Core Infrastructure Deployment – The Control Plane
+## 3. Phase 2: Core Infrastructure Deployment – The Control Plane
 Objective: Phase 2 transitions from the local laptop to the cloud. The objective is to deploy the production-grade Control Plane on AWS. This phase addresses the critical architectural bifurcation between the Control Plane (management) and Data Plane (execution), and the specific decision to utilize Amazon EKS over ECS due to the privileged execution requirements of Dagger.
-3.1 The EKS-First Decision: Architecture and Justification
+### 3.1 The EKS-First Decision: Architecture and Justification
 The decision to standardize on Amazon EKS is driven by the specific constraints of the "Muscular" layer (Dagger). Dagger functions by spinning up ephemeral containers to execute build steps. This "Docker-in-Docker" (DinD) pattern requires the host container to possess privileged capabilities to access the kernel features needed for overlay filesystems and nested containerization.
  * The Fargate Limitation: AWS Fargate enforces a strict security boundary that prohibits privileged: true containers. It effectively blocks the Dagger Engine from functioning.
  * The Solution: We must maintain a hybrid EKS cluster. The Control Plane services can run on managed Fargate nodes for ease of operations, but the Data Plane workers (specifically the Dagger Executors) must run on EC2 Managed Node Groups.
-3.2 Cluster Topology and Node Group Strategy
+### 3.2 Cluster Topology and Node Group Strategy
 To ensure security and performance, we implement a strict node isolation strategy using Kubernetes Taints and Tolerations.
-3.2.1 Control Plane Node Group
+#### 3.2.1 Control Plane Node Group
  * Target: System components (CoreDNS, Temporal Frontend, MCP Host, Ingress Controllers).
  * Configuration: AWS Fargate Profiles or general-purpose EC2 (e.g., m5.large).
  * Rationale: These services are long-lived, stateless, and do not require privileged access. Fargate reduces the patching overhead.
-3.2.2 The "Heavy" Worker Node Group (The Builder Fleet)
+#### 3.2.2 The "Heavy" Worker Node Group (The Builder Fleet)
  * Target: Temporal Workers executing Dagger Activities.
  * Instance Type: c5d.2xlarge or i3en.xlarge.
  * Constraint: Local NVMe: Dagger performance is heavily dependent on caching. We select instances with local NVMe SSDs to serve as the build cache layer. This avoids the latency of network-attached storage (EBS) for high-churn build artifacts.
  * Taint Configuration: We apply a Taint: key=shinobi.io/workload, value=privileged, effect=NoSchedule.
    * Effect: This ensures that only pods that explicitly "tolerate" this taint can be scheduled here. This physically isolates the privileged Dagger workloads from the rest of the cluster, mitigating the risk of a container escape affecting the Control Plane.
  * Security Context: The DaemonSet for the Dagger Engine is configured with securityContext: privileged: true. We create a specific namespace (shinobi-executors) and exempt it from the restrictive Pod Security Standards (PSS) using OPA Gatekeeper policies, while strictly enforcing PSS on all other namespaces.
-3.3 Temporal Cluster Architecture
+### 3.3 Temporal Cluster Architecture
 While Temporal Cloud is an option, for a self-hosted reference implementation on EKS, we deploy the full Temporal cluster topology.
  * Services: We deploy the four core Temporal services: Frontend, History, Matching, and Worker.
  * Persistence Layer: We utilize Amazon RDS for PostgreSQL as the durable store for workflow history. This provides strong consistency guarantees.
  * Visibility Layer: We deploy Elasticsearch (or Amazon OpenSearch) to power the advanced filtering capabilities required by the Backstage plugin (e.g., "Show me all workflows waiting for approval initiated by User X").
- * Archival: We configure Temporal Archival to S3. This moves workflow histories from hot storage (RDS) to cold storage (S3) after a retention period (e.g., 7 days). This is critical for maintaining an immutable audit trail for compliance purposes.
-3.4 The Centralized MCP Host & Gateway
+ * Archival: We configure Temporal Archival to S3. This moves workflow histories from hot storage (RDS) to cold storage (S3) after a configured retention window. This is critical for maintaining an immutable audit trail for compliance purposes.
+### 3.4 The Centralized MCP Host & Gateway
 To solve the "N×M" connectivity problem, we deploy a centralized MCP Host service.
  * Architecture: The MCP Host runs as a stateless Deployment in the Control Plane.
  * Transport: Server-Sent Events (SSE): Unlike the local STDIO transport, the production environment utilizes SSE over HTTP.
    * Mechanism: The MCP Host exposes an HTTP endpoint (/sse). Temporal Workers connect to this endpoint to receive tool calls and stream results.
    * Benefit: SSE allows for a decoupled, distributed architecture where the Agent and the Tool do not need to reside on the same physical machine. It also supports load balancing and standard network security policies (TLS, WAF).
  * Discovery: The MCP Host implements a dynamic discovery endpoint. When a new Tool Server is deployed (e.g., a new "Jira Integration"), it registers itself with the Host. The Agents periodically poll the Host to update their internal tool definitions, ensuring they always have access to the latest capabilities without redeployment.
-4. Phase 3: The Cognitive Layer – LangGraph & Tooling
+## 4. Phase 3: The Cognitive Layer – LangGraph & Tooling
 Objective: With the infrastructure in place, Phase 3 focuses on implementing the "Brain" (LangGraph) and the "Senses" (MCP Tools). This phase realizes the core value proposition of the platform: the ability to reason about infrastructure and execute complex, multi-step workflows.
-4.1 The Tool Ecosystem: MCP Server Implementation
+### 4.1 The Tool Ecosystem: MCP Server Implementation
 We implement a suite of MCP Servers that act as the interface between the agents and the external world. Each server runs as a microservice within the EKS cluster.
-4.1.1 The AWS IaC MCP Server
+#### 4.1.1 The AWS IaC MCP Server
 This server provides the agent with "grounded" access to AWS.
  * Capabilities:
    * ListResources(region, service): Discover existing infrastructure.
    * GetStackStatus(stack_name): Check CloudFormation/Terraform state.
    * ValidateTemplate(template_body): Run static analysis (cfn-lint) on code generated by the agent before deployment.
  * Security: This server runs with a strictly scoped IAM Role for Service Accounts (IRSA). It provides Read-Only access by default, preventing the agent from bypassing the approval workflow.
-4.1.2 The Dagger Execution MCP Server
+#### 4.1.2 The Dagger Execution MCP Server
 This server exposes the raw execution power of Dagger as a structured tool.
  * Primitive: RunPipeline(module_url, function_name, arguments).
  * Mechanism: When called, this server connects to the Dagger Engine (running on the "Heavy" nodes) via the 

--- a/docs/spec/review.md
+++ b/docs/spec/review.md
@@ -115,7 +115,7 @@ Manifest → **Schema validation** → **Context hydration** (env/defaults/secre
 **Actions (tickets):**
 
 * **Define canonical JSON Schema** for `service.yml` (generate from TS types; ship with the CLI for IDE validation).
-* **Introduce semantic validators** (e.g., “FedRAMP High ⇒ Multi‑AZ true, encryption KMS CMK, backup ≥ 35 days”) tied to compliance profiles. (README already hints at these rules. ([GitHub][1]))
+* **Introduce semantic validators** (e.g., “FedRAMP High ⇒ Multi‑AZ true, encryption KMS CMK, backup ≥ retention window”) tied to compliance profiles. (README already hints at these rules. ([GitHub][1]))
 * **Version the schema** (`manifestVersion`) and provide a **migration tool** (`svc migrate`) with codemods & release notes.
 * Add **field‑level deprecation tags** and a **deprecation linter** (fail CI on deprecated fields w/o suppression).
 * **Context hydrators**: env vars, secrets, feature flags (OpenFeature), and org defaults—deterministic order (document a **configuration precedence chain**).
@@ -291,9 +291,9 @@ A file named `service-backstage-portal.yml` in the repo root hints at this direc
 
 ---
 
-## 16) 30/60/90 Roadmap (ticket‑ready)
+## 16) Kanban Flow Status (ticket‑ready)
 
-**Next 30 days**
+**Now**
 
 * [ ] Establish **pnpm** + **Nx/Turbo**; split into `packages/core`, `packages/cli`, `packages/components/*`.
 * [ ] Author **JSON Schema** + TS types for `service.yml`; wire into CLI validation.
@@ -302,7 +302,7 @@ A file named `service-backstage-portal.yml` in the repo root hints at this direc
 * [ ] Add **snapshot tests** for synth of each example manifest.
 * [ ] Backstage Scaffolder v1 using the schema; render `svc plan` artifact in PR.
 
-**Next 60 days**
+**Next**
 
 * [ ] Introduce **Changesets**; publish versioned packages; generate SBOMs.
 * [ ] Build **evidence export** (OSCAL JSON) with links to resources; store in S3.
@@ -310,7 +310,7 @@ A file named `service-backstage-portal.yml` in the repo root hints at this direc
 * [ ] `svc explain` & `svc graph` commands.
 * [ ] OpenTelemetry defaults for `lambda-api` and standard structured logging.
 
-**Next 90 days**
+**Later**
 
 * [ ] FedRAMP High policy pack & **cross‑account org guardrails**.
 * [ ] MCP server hardened; Backstage plugin for explain/scorecards.


### PR DESCRIPTION
### Motivation
- Implement the Phase 1 “Golden Path” durable agent that composes planning (LLM), tool execution (MCP/Dagger), and orchestration (Temporal). 
- Enforce engineering standards by removing SRP/DIP violations and centralizing dependency injection and runtime configuration. 
- Provide an offline-first testing story and test scaffolding so workflows and activities can be validated without network access. 
- Surface project status and replace date-based timelines with a Kanban-style status to make handoff to the next engineer explicit.

### Description
- Added a new `apps/harmony` package with runtime config, `docker-compose.golden-path.yml`, `package.json`, and `README.md` to run the local Golden Path stack. 
- Implemented DI-backed runtime wiring and components including `src/bootstrap/dependencies.js`, `src/config/runtime.js`, MCP client/server (`src/mcp/*`), Dagger repository scanner (`src/dagger/scan-repo.js`), LLM client + structured-output helpers (`src/llm/*`), LangGraph agent graph and planner/reviewer (`src/agent/*`), and Temporal workflows/worker/run-local (`src/workflow/*`). 
- Split monolithic activities into discrete activities and factories (discover/generate/execute/review) so external clients are injected rather than instantiated in activities. 
- Added offline test suites under `apps/harmony/test/*` (planner/reviewer, dagger container-definition test, and a Temporal durability test) and converted `docs/harmony` to a Markdown project status document with Kanban flow entries.

### Testing
- Unit and integration-style tests were added (`apps/harmony/test/*`) including a Temporal durability test that uses `@temporalio/testing`, but these tests were not executed in this environment due to dependency installation being blocked by the npm registry (403). 
- The change that was committed in this rollout was documentation-only (`docs/harmony` Kanban status) and therefore no automated tests were run as part of this commit. 
- To run the added tests locally or in CI, run `pnpm install` (ensuring registry/credentials are available) then `cd apps/harmony && pnpm test` to execute the test suite. 
- If CI fails on registry access, validate by running the tests in an environment with proper npm registry access and `HARMONY_LLM_API_KEY` set for any online LLM provider tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696190e344708333b94afc027e8c6af7)