### PR TITLE
Add rollback preflight check to `shinobi up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ npm run test:e2e
 npm run test:coverage
 ```
 
+### Deployment
+
+Use `shinobi up` to deploy a service manifest. The command checks CloudFormation
+stack status before deployment and will stop if the stack is in a terminal
+rollback state (for example, `ROLLBACK_COMPLETE`) so you can delete and recreate
+the stack safely before retrying.
+
 ### MCP Server
 
 ```bash

--- a/apps/svc/src/cli/__tests__/up-command.test.ts
+++ b/apps/svc/src/cli/__tests__/up-command.test.ts
@@ -4,6 +4,7 @@ import { UpCommand } from '../up-command.js';
 import type { UpOptions } from '../up-command.js';
 import type { Logger } from '../console-logger.js';
 import type { FileDiscovery } from '@shinobi/core';
+import { createMockStackNotFoundError } from './helpers/mock-aws.js';
 jest.mock('../utils/service-synthesizer.js', () => ({
   readManifest: jest.fn(),
   synthesizeService: jest.fn()
@@ -11,6 +12,12 @@ jest.mock('../utils/service-synthesizer.js', () => ({
 
 const deployMock = jest.fn();
 let capturedProducer: any;
+const cfnSendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-cloudformation', () => ({
+  CloudFormationClient: jest.fn().mockImplementation(() => ({ send: cfnSendMock })),
+  DescribeStacksCommand: jest.fn().mockImplementation((input: any) => input)
+}));
 
 jest.mock('@aws-cdk/cli-lib-alpha', () => ({
   AwsCdkCli: class {
@@ -59,6 +66,7 @@ describe('UpCommand', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     deployMock.mockReset();
+    cfnSendMock.mockReset();
     capturedProducer = undefined;
     (fileDiscovery.findManifest as jest.Mock).mockResolvedValue(manifestPath);
     readManifestMock.mockResolvedValue({
@@ -84,6 +92,9 @@ describe('UpCommand', () => {
       outputDir: path.join(os.tmpdir(), 'synth-output'),
       components: []
     });
+    cfnSendMock.mockResolvedValue({
+      Stacks: [{ StackStatus: 'CREATE_COMPLETE' }]
+    });
     deployMock.mockImplementation(async () => {
       if (capturedProducer) {
         await capturedProducer.produce({});
@@ -108,5 +119,27 @@ describe('UpCommand', () => {
     expect(result.exitCode).toBe(1);
     expect(logger.warn).toHaveBeenCalledWith('Deployment cancelled by user.');
     expect(deployMock).not.toHaveBeenCalled();
+  });
+
+  it('fails early when stack is in terminal rollback status', async () => {
+    cfnSendMock.mockResolvedValueOnce({
+      Stacks: [{ StackStatus: 'ROLLBACK_COMPLETE' }]
+    });
+
+    const result = await upCommand.execute(baseOptions);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.error).toContain('ROLLBACK_COMPLETE');
+    expect(deployMock).not.toHaveBeenCalled();
+  });
+
+  it('continues deploy when stack does not exist', async () => {
+    cfnSendMock.mockRejectedValueOnce(createMockStackNotFoundError());
+
+    const result = await upCommand.execute(baseOptions);
+
+    expect(result.success).toBe(true);
+    expect(deployMock).toHaveBeenCalled();
   });
 });

--- a/apps/svc/src/cli/up-command.ts
+++ b/apps/svc/src/cli/up-command.ts
@@ -24,6 +24,10 @@ import * as path from 'path';
 import * as fsp from 'fs/promises';
 import inquirer from 'inquirer';
 import { AwsCdkCli, RequireApproval } from '@aws-cdk/cli-lib-alpha';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand
+} from '@aws-sdk/client-cloudformation';
 import { FileDiscovery } from '@shinobi/core';
 import { Logger } from './console-logger.js';
 import {
@@ -67,6 +71,28 @@ interface UpDependencies {
   logger: Logger;
 }
 
+const isStackNotFound = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as { name?: string; message?: string };
+  return err.name === 'ValidationError' && err.message?.includes('does not exist') === true;
+};
+
+const isTerminalRollbackStatus = (status?: string): boolean => {
+  if (!status) {
+    return false;
+  }
+
+  return new Set([
+    'ROLLBACK_COMPLETE',
+    'ROLLBACK_FAILED',
+    'UPDATE_ROLLBACK_COMPLETE',
+    'UPDATE_ROLLBACK_FAILED'
+  ]).has(status);
+};
+
 export class UpCommand {
   constructor(private readonly dependencies: UpDependencies) {}
 
@@ -106,6 +132,25 @@ export class UpCommand {
       if (options.profile) {
         process.env.AWS_PROFILE = options.profile;
         logger.info(`Using AWS profile: ${options.profile}`);
+      }
+
+      const cfnClient = new CloudFormationClient({ region });
+      try {
+        const stackResponse = await cfnClient.send(
+          new DescribeStacksCommand({ StackName: stackName })
+        );
+        const stackStatus = stackResponse.Stacks?.[0]?.StackStatus;
+        if (isTerminalRollbackStatus(stackStatus)) {
+          return {
+            success: false,
+            exitCode: 2,
+            error: `Stack ${stackName} is in ${stackStatus}. Delete the stack before deploying again.`
+          };
+        }
+      } catch (error) {
+        if (!isStackNotFound(error)) {
+          throw error;
+        }
       }
 
       let latestSynth: SynthesizeServiceResult | undefined;


### PR DESCRIPTION
### Motivation
- Deploys were failing when a target CloudFormation stack was stuck in a terminal rollback state because `shinobi up` did not check stack status before invoking CDK deploy. 
- The change prevents repeatedly triggering CDK deploy against unrecoverable stack states and surfaces a clear remediation message. 
- Early-failing is preferred to noisy deploy-time errors so operators can delete or recover the stack first.

### Description
- Add a CloudFormation preflight using `DescribeStacks` in `apps/svc/src/cli/up-command.ts` and helper predicates `isStackNotFound` and `isTerminalRollbackStatus`. 
- Return early with a user-friendly error when the stack is in a terminal rollback state (e.g., `ROLLBACK_COMPLETE`).
- Add unit tests that mock the CloudFormation client to cover the terminal-rollback and stack-not-found paths in `apps/svc/src/cli/__tests__/up-command.test.ts`.
- Document the preflight behavior in `README.md` under the Deployment section.

### Testing
- Added unit tests in `apps/svc/src/cli/__tests__/up-command.test.ts` for rollback detection and missing-stack behavior that mock `@aws-sdk/client-cloudformation`.
- No automated test suite was executed as part of this PR (tests were added but not run in CI for this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960aaf24c848333aca2ecf0552f8a6a)