### PR TITLE
Initialize OpenTelemetry SDK and refine Dagger `run-local` to use Temporal/Ollama sidecars

### DIFF
--- a/apps/harmony/README.md
+++ b/apps/harmony/README.md
@@ -52,6 +52,51 @@ HARMONY_REPO="https://github.com/modelcontextprotocol/servers" pnpm start:client
 
 The workflow runs the Plan → Execute → Review steps and outputs the resulting state, including the README contents, file tree, and review notes.
 
+## Run the OpsNarrative workflow
+
+The OpsNarrative workflow aggregates Linear, Git, and PagerDuty data, synthesizes a report using a configurable AI provider, and delivers it to Slack with a local-file fallback.
+
+### Run locally with Dagger
+
+From the repo root:
+
+```bash
+cd apps/harmony
+dagger call run-local --source . --ai-provider OLLAMA --model llama3
+```
+
+Optional inputs:
+
+- `ONW_PROVIDER_CONFIG` (JSON) overrides the provider config injected by Dagger.
+- `ONW_FLAG_OVERRIDES` (JSON) controls OpenFeature flags such as `enable-linear-source`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` sets the OTLP exporter endpoint (defaults to `http://localhost:4318/v1/traces`).
+
+If you use the Ollama sidecar, ensure the model is pulled before running:
+
+```bash
+docker exec -it <ollama-container> ollama pull llama3
+```
+
+### Run locally with Temporal
+
+```bash
+cd apps/harmony
+HARMONY_WORKFLOW=ops-narrative \\
+ONW_PROVIDER_CONFIG='{\"type\":\"OLLAMA\",\"host\":\"http://localhost:11434\",\"model\":\"llama3\"}' \\
+ONW_LINEAR_TEAM=PLAT \\
+ONW_GIT_PROVIDER=GITLAB \\
+ONW_GIT_REPO=platform%2Fops-narrative \\
+ONW_PD_SERVICE=P123456 \\
+pnpm start:client
+```
+
+Required credentials by source:
+
+- `LINEAR_API_TOKEN`
+- `GITLAB_TOKEN` or `BITBUCKET_TOKEN` (depending on `ONW_GIT_PROVIDER`)
+- `PAGERDUTY_API_TOKEN`
+- `SLACK_WEBHOOK_URL` (only if delivering to Slack)
+
 ## Troubleshooting
 
 - **Dagger connection errors**: ensure the Dagger engine container is running and the Docker socket is accessible.

--- a/apps/harmony/dagger.json
+++ b/apps/harmony/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "ops-narrative",
+  "sdk": "typescript",
+  "source": "dagger",
+  "engineVersion": "v0.11.1"
+}

--- a/apps/harmony/dagger/main.ts
+++ b/apps/harmony/dagger/main.ts
@@ -1,0 +1,96 @@
+import { dag, Container, Directory, Service, object, func } from "@dagger.io/dagger";
+
+const DEFAULT_NODE_IMAGE = "node:20-alpine";
+const TEMPORAL_IMAGE = "temporalio/admin-tools:latest";
+const OLLAMA_IMAGE = "ollama/ollama:latest";
+
+function baseNode(source: Directory) {
+  return dag
+    .container()
+    .from(DEFAULT_NODE_IMAGE)
+    .withMountedDirectory("/src", source)
+    .withWorkdir("/src")
+    .withExec(["corepack", "enable"])
+    .withExec(["pnpm", "install", "--frozen-lockfile"]);
+}
+
+function resolveProviderConfig(aiProvider: string, providerConfigJson?: string) {
+  if (providerConfigJson) {
+    return providerConfigJson;
+  }
+
+  const normalized = aiProvider.toUpperCase();
+  if (normalized === "OPENAI") {
+    return JSON.stringify({ type: "OPENAI", model: "gpt-4o-mini" });
+  }
+
+  if (normalized === "BEDROCK") {
+    return JSON.stringify({ type: "BEDROCK", region: "us-east-1", modelId: "anthropic.claude-3-sonnet-20240229-v1:0" });
+  }
+
+  return JSON.stringify({ type: "OLLAMA", host: "http://localhost:11434", model: "llama3" });
+}
+
+@object()
+export class OpsNarrative {
+  @func()
+  async test(source: Directory): Promise<string> {
+    await baseNode(source)
+      .withExec(["pnpm", "-C", "apps/harmony", "test:vitest"])
+      .sync();
+
+    return "vitest completed";
+  }
+
+  @func()
+  async runLocal(
+    source: Directory,
+    aiProvider: string = "OLLAMA",
+    model: string = "llama3",
+    providerConfigJson?: string
+  ): Promise<Container> {
+    const temporal = dag
+      .container()
+      .from(TEMPORAL_IMAGE)
+      .withExposedPort(7233)
+      .withExposedPort(8233)
+      .withExec(["temporal", "server", "start-dev", "--ip", "0.0.0.0", "--ui-port", "8233"])
+      .asService();
+
+    let ollamaService: Service | undefined;
+    if (aiProvider.toUpperCase() === "OLLAMA") {
+      const modelCache = dag.cacheVolume("ollama-models");
+      ollamaService = dag
+        .container()
+        .from(OLLAMA_IMAGE)
+        .withMountedCache("/root/.ollama", modelCache)
+        .withExposedPort(11434)
+        .withExec(["ollama", "serve"])
+        .asService();
+    }
+
+    let worker = baseNode(source)
+      .withWorkdir("/src/apps/harmony")
+      .withServiceBinding("temporal", temporal)
+      .withEnvVariable("TEMPORAL_ADDRESS", "temporal:7233")
+      .withExec(["node", "src/workflow/worker.js"])
+      .asService();
+
+    const providerConfig = resolveProviderConfig(aiProvider, providerConfigJson);
+    let client = baseNode(source)
+      .withWorkdir("/src/apps/harmony")
+      .withServiceBinding("temporal", temporal)
+      .withServiceBinding("worker", worker)
+      .withEnvVariable("TEMPORAL_ADDRESS", "temporal:7233")
+      .withEnvVariable("HARMONY_WORKFLOW", "ops-narrative")
+      .withEnvVariable("ONW_PROVIDER_CONFIG", providerConfig);
+
+    if (ollamaService) {
+      client = client
+        .withServiceBinding("ollama", ollamaService)
+        .withEnvVariable("ONW_PROVIDER_CONFIG", JSON.stringify({ type: "OLLAMA", host: "http://ollama:11434", model }));
+    }
+
+    return client.withExec(["node", "src/workflow/run-local.js"]);
+  }
+}

--- a/apps/harmony/package.json
+++ b/apps/harmony/package.json
@@ -8,15 +8,27 @@
     "start:mcp": "node src/mcp/server.js",
     "start:worker": "node src/workflow/worker.js",
     "start:client": "node src/workflow/run-local.js",
-    "test": "node --test"
+    "test": "node --test",
+    "test:vitest": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.620.0",
+    "@aws-sdk/credential-provider-node": "^3.620.0",
     "@dagger.io/dagger": "^0.11.1",
     "@langchain/langgraph": "^0.0.42",
     "@modelcontextprotocol/sdk": "^0.4.0",
+    "@openfeature/server-sdk": "^1.9.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.51.0",
+    "@opentelemetry/resources": "^1.24.0",
+    "@opentelemetry/sdk-node": "^0.51.0",
+    "@opentelemetry/semantic-conventions": "^1.24.0",
     "@temporalio/client": "^1.10.4",
     "@temporalio/worker": "^1.10.4",
     "@temporalio/workflow": "^1.10.4",
     "zod": "^4.1.5"
+  },
+  "devDependencies": {
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/harmony/src/instrumentation.js
+++ b/apps/harmony/src/instrumentation.js
@@ -1,0 +1,23 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+
+const sdk = new NodeSDK({
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: "ops-narrative-worker"
+  }),
+  traceExporter: new OTLPTraceExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://localhost:4318/v1/traces"
+  })
+});
+
+sdk.start();
+
+process.on("SIGTERM", () => {
+  sdk
+    .shutdown()
+    .then(() => console.log("Tracing terminated"))
+    .catch((error) => console.log("Error terminating tracing", error))
+    .finally(() => process.exit(0));
+});

--- a/apps/harmony/src/ops-narrative/__tests__/activities.test.js
+++ b/apps/harmony/src/ops-narrative/__tests__/activities.test.js
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchLinearData,
+  getWorkflowFlags,
+  synthesizeReport
+} from "../activities.js";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env = { ...originalEnv };
+});
+
+describe("OpsNarrative activities", () => {
+  it("returns empty issues on Linear 404", async () => {
+    process.env.LINEAR_API_TOKEN = "token";
+    const response = {
+      ok: false,
+      status: 404,
+      text: vi.fn().mockResolvedValue("")
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+
+    const result = await fetchLinearData({ teamKey: "UNK" });
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("synthesizes report with Ollama provider", async () => {
+    const response = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({ response: "Summary" })
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+
+    const result = await synthesizeReport({
+      rawContext: { incidents: [] },
+      providerConfig: { type: "OLLAMA", host: "http://ollama", model: "llama3" }
+    });
+
+    expect(result.content).toBe("Summary");
+    expect(result.provider).toBe("OLLAMA");
+  });
+
+  it("resolves OpenFeature flags from overrides", async () => {
+    process.env.ONW_FLAG_OVERRIDES = JSON.stringify({
+      "enable-linear-source": false
+    });
+
+    const flags = await getWorkflowFlags();
+    expect(flags.enableLinearSource).toBe(false);
+    expect(flags.enableGitSource).toBe(true);
+  });
+});

--- a/apps/harmony/src/ops-narrative/activities.js
+++ b/apps/harmony/src/ops-narrative/activities.js
@@ -1,0 +1,266 @@
+import { trace } from "@opentelemetry/api";
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  GitOpsInputSchema,
+  GitOpsOutputSchema,
+  LinearInputSchema,
+  LinearOutputSchema,
+  LocalDeliveryInputSchema,
+  LocalDeliveryOutputSchema,
+  PagerDutyInputSchema,
+  PagerDutyOutputSchema,
+  SlackDeliveryInputSchema,
+  SlackDeliveryOutputSchema,
+  SynthesizeReportInputSchema,
+  SynthesizeReportOutputSchema
+} from "./schemas.js";
+import { fetchJson } from "./http-client.js";
+import { generateWithProvider } from "./ai-providers.js";
+import { resolveWorkflowFlags } from "./flags.js";
+
+const tracer = trace.getTracer("ops-narrative");
+
+function lookbackIso(hours) {
+  const since = new Date(Date.now() - hours * 60 * 60 * 1000);
+  return since.toISOString();
+}
+
+export async function fetchLinearData(input) {
+  const payload = LinearInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("linear.fetch_issues", async (span) => {
+    span.setAttribute("linear.team_id", payload.teamKey);
+    try {
+      const token = process.env.LINEAR_API_TOKEN ?? "";
+      if (!token) {
+        throw new Error("LINEAR_API_TOKEN is required for Linear data fetch");
+      }
+      const query = {
+        query: `query ($teamKey: String!, $since: DateTime!) {\n  issues(filter: { team: { key: { eq: $teamKey } }, completedAt: { gte: $since } }) {\n    nodes { id title url completedAt }\n  }\n}`,
+        variables: { teamKey: payload.teamKey, since: lookbackIso(payload.lookbackHours) }
+      };
+
+      const { response, body } = await fetchJson("https://api.linear.app/graphql", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: token
+        },
+        body: JSON.stringify(query)
+      });
+
+      if (!response.ok) {
+        return LinearOutputSchema.parse({ issues: [] });
+      }
+
+      const issues = body?.data?.issues?.nodes ?? [];
+      return LinearOutputSchema.parse({ issues });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function fetchGitOpsData(input) {
+  const payload = GitOpsInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("git.fetch_changes", async (span) => {
+    span.setAttribute("git.provider", payload.providerType);
+    span.setAttribute("git.repo", payload.repoId);
+    try {
+      if (payload.providerType === "GITLAB") {
+        const token = process.env.GITLAB_TOKEN ?? "";
+        if (!token) {
+          throw new Error("GITLAB_TOKEN is required for GitLab data fetch");
+        }
+        const url = `https://gitlab.com/api/v4/projects/${encodeURIComponent(payload.repoId)}/merge_requests?state=merged`;
+        const { response, body } = await fetchJson(url, {
+          headers: { "PRIVATE-TOKEN": token }
+        });
+
+        if (!response.ok) {
+          return GitOpsOutputSchema.parse({ changes: [] });
+        }
+
+        const changes = (body ?? []).map((mr) => ({
+          id: String(mr.id),
+          title: mr.title,
+          url: mr.web_url,
+          mergedAt: mr.merged_at,
+          author: mr.author?.name
+        }));
+
+        return GitOpsOutputSchema.parse({ changes });
+      }
+
+      const token = process.env.BITBUCKET_TOKEN ?? "";
+      if (!token) {
+        throw new Error("BITBUCKET_TOKEN is required for Bitbucket data fetch");
+      }
+      const url = `https://api.bitbucket.org/2.0/repositories/${payload.repoId}/pullrequests?state=MERGED`;
+      const { response, body } = await fetchJson(url, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+
+      if (!response.ok) {
+        return GitOpsOutputSchema.parse({ changes: [] });
+      }
+
+      const changes = (body?.values ?? []).map((pr) => ({
+        id: String(pr.id),
+        title: pr.title,
+        url: pr.links?.html?.href,
+        mergedAt: pr.updated_on,
+        author: pr.author?.display_name
+      }));
+
+      return GitOpsOutputSchema.parse({ changes });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function fetchPagerDutyData(input) {
+  const payload = PagerDutyInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("pagerduty.fetch_incidents", async (span) => {
+    span.setAttribute("pagerduty.service_id", payload.serviceId);
+    try {
+      const token = process.env.PAGERDUTY_API_TOKEN ?? "";
+      if (!token) {
+        throw new Error("PAGERDUTY_API_TOKEN is required for PagerDuty data fetch");
+      }
+      const since = lookbackIso(payload.lookbackHours);
+      const url = `https://api.pagerduty.com/incidents?since=${encodeURIComponent(since)}&service_ids[]=${encodeURIComponent(payload.serviceId)}`;
+      const { response, body } = await fetchJson(url, {
+        headers: {
+          Accept: "application/vnd.pagerduty+json;version=2",
+          Authorization: `Token token=${token}`
+        }
+      });
+
+      if (!response.ok) {
+        return PagerDutyOutputSchema.parse({ incidents: [] });
+      }
+
+      const incidents = (body?.incidents ?? []).map((incident) => ({
+        id: incident.id,
+        title: incident.title,
+        url: incident.html_url,
+        status: incident.status,
+        createdAt: incident.created_at,
+        resolvedAt: incident.resolved_at
+      }));
+
+      return PagerDutyOutputSchema.parse({ incidents });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function synthesizeReport(input) {
+  const payload = SynthesizeReportInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("ai.synthesize_report", async (span) => {
+    try {
+      const contextText = JSON.stringify(payload.rawContext, null, 2);
+      const prompt = `You are OpsNarrative. Summarize the following operational context into a concise report with sections for delivery, incidents, and code changes.\n\nContext:\n${contextText}`;
+      const content = await generateWithProvider({
+        prompt,
+        providerConfig: payload.providerConfig
+      });
+
+      return SynthesizeReportOutputSchema.parse({
+        content,
+        provider: payload.providerConfig.type
+      });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function sendSlackReport(input) {
+  const payload = SlackDeliveryInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("notify.slack", async (span) => {
+    try {
+      const webhookUrl = payload.webhookUrl ?? process.env.SLACK_WEBHOOK_URL;
+      if (!webhookUrl) {
+        throw new Error("Slack webhook URL is required");
+      }
+
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: payload.content })
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Slack delivery failed: ${response.status} ${text}`);
+      }
+
+      return SlackDeliveryOutputSchema.parse({
+        delivered: true,
+        status: response.status
+      });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function writeLocalReport(input) {
+  const payload = LocalDeliveryInputSchema.parse(input);
+
+  return await tracer.startActiveSpan("notify.local", async (span) => {
+    try {
+      const outputDir = payload.outputDir ?? process.env.ONW_REPORT_OUTPUT_DIR ?? "./out";
+      await mkdir(outputDir, { recursive: true });
+      const filePath = join(outputDir, `ops-narrative-${Date.now()}.md`);
+      await writeFile(filePath, payload.content, "utf-8");
+
+      return LocalDeliveryOutputSchema.parse({
+        delivered: true,
+        filePath
+      });
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export async function getWorkflowFlags() {
+  return await tracer.startActiveSpan("workflow.flags", async (span) => {
+    try {
+      return await resolveWorkflowFlags();
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/apps/harmony/src/ops-narrative/ai-providers.js
+++ b/apps/harmony/src/ops-narrative/ai-providers.js
@@ -1,0 +1,118 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { fromNodeProviderChain } from "@aws-sdk/credential-provider-node";
+import { trace } from "@opentelemetry/api";
+import { AiProviderConfigSchema } from "./schemas.js";
+
+const tracer = trace.getTracer("ops-narrative");
+
+function createBedrockClient(region) {
+  return new BedrockRuntimeClient({
+    region,
+    credentials: fromNodeProviderChain()
+  });
+}
+
+async function callBedrock({ prompt, modelId, region }) {
+  const client = createBedrockClient(region);
+  const body = JSON.stringify({
+    prompt,
+    max_tokens_to_sample: 1024
+  });
+
+  const command = new InvokeModelCommand({
+    body,
+    modelId,
+    contentType: "application/json",
+    accept: "application/json"
+  });
+
+  const response = await client.send(command);
+  const payload = new TextDecoder().decode(response.body);
+  const parsed = JSON.parse(payload);
+  return parsed.completion ?? parsed.output ?? "";
+}
+
+async function callOllama({ prompt, host, model }) {
+  const url = `${host.replace(/\/$/, "")}/api/generate`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, prompt, stream: false })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Ollama request failed: ${response.status} ${text}`);
+  }
+
+  const payload = await response.json();
+  return payload.response ?? "";
+}
+
+async function callOpenAi({ prompt, model, apiKey }) {
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is required for OpenAI provider");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.2
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI request failed: ${response.status} ${text}`);
+  }
+
+  const payload = await response.json();
+  return payload.choices?.[0]?.message?.content ?? "";
+}
+
+export async function generateWithProvider({ prompt, providerConfig }) {
+  const config = AiProviderConfigSchema.parse(providerConfig);
+
+  return await tracer.startActiveSpan("ai.generate", async (span) => {
+    span.setAttribute("ai.provider", config.type);
+
+    try {
+      switch (config.type) {
+        case "BEDROCK":
+          span.setAttribute("ai.model", config.modelId);
+          return await callBedrock({
+            prompt,
+            modelId: config.modelId,
+            region: config.region
+          });
+        case "OLLAMA":
+          span.setAttribute("ai.model", config.model);
+          return await callOllama({
+            prompt,
+            host: config.host,
+            model: config.model
+          });
+        case "OPENAI":
+          span.setAttribute("ai.model", config.model);
+          return await callOpenAi({
+            prompt,
+            model: config.model,
+            apiKey: process.env.OPENAI_API_KEY ?? ""
+          });
+        default:
+          throw new Error(`Unsupported AI provider: ${config.type}`);
+      }
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/apps/harmony/src/ops-narrative/flags.js
+++ b/apps/harmony/src/ops-narrative/flags.js
@@ -1,0 +1,44 @@
+import { InMemoryProvider, OpenFeature } from "@openfeature/server-sdk";
+import { WorkflowFlagsSchema } from "./schemas.js";
+
+const DEFAULT_FLAGS = {
+  "enable-linear-source": true,
+  "enable-git-source": true,
+  "enable-pagerduty-source": true,
+  "enable-slack-delivery": true
+};
+
+function parseFlagOverrides() {
+  const raw = process.env.ONW_FLAG_OVERRIDES ?? "{}";
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  } catch (error) {
+    return {};
+  }
+  return {};
+}
+
+export async function resolveWorkflowFlags() {
+  const overrides = parseFlagOverrides();
+  const provider = new InMemoryProvider({
+    flags: {
+      ...DEFAULT_FLAGS,
+      ...overrides
+    }
+  });
+
+  OpenFeature.setProvider(provider);
+  const client = OpenFeature.getClient("ops-narrative-workflow");
+
+  const flags = {
+    enableLinearSource: await client.getBooleanValue("enable-linear-source", true),
+    enableGitSource: await client.getBooleanValue("enable-git-source", true),
+    enablePagerDutySource: await client.getBooleanValue("enable-pagerduty-source", true),
+    enableSlackDelivery: await client.getBooleanValue("enable-slack-delivery", true)
+  };
+
+  return WorkflowFlagsSchema.parse(flags);
+}

--- a/apps/harmony/src/ops-narrative/http-client.js
+++ b/apps/harmony/src/ops-narrative/http-client.js
@@ -1,0 +1,28 @@
+import { trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("ops-narrative");
+
+export async function fetchJson(url, options = {}) {
+  return await tracer.startActiveSpan("http.fetch", async (span) => {
+    span.setAttribute("http.url", url);
+    span.setAttribute("http.method", options.method ?? "GET");
+
+    try {
+      const response = await fetch(url, options);
+      span.setAttribute("http.status_code", response.status);
+
+      let body = null;
+      if (response.status !== 204) {
+        const text = await response.text();
+        body = text ? JSON.parse(text) : null;
+      }
+
+      return { response, body };
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/apps/harmony/src/ops-narrative/schemas.js
+++ b/apps/harmony/src/ops-narrative/schemas.js
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+export const LinearInputSchema = z.object({
+  teamKey: z.string().min(1),
+  lookbackHours: z.number().int().positive().default(168)
+});
+
+export const LinearIssueSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string().url().optional(),
+  completedAt: z.string().optional()
+});
+
+export const LinearOutputSchema = z.object({
+  issues: z.array(LinearIssueSchema)
+});
+
+export const GitOpsInputSchema = z.object({
+  providerType: z.enum(["GITLAB", "BITBUCKET"]),
+  repoId: z.string().min(1)
+});
+
+export const GitOpsChangeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string().url().optional(),
+  mergedAt: z.string().optional(),
+  author: z.string().optional()
+});
+
+export const GitOpsOutputSchema = z.object({
+  changes: z.array(GitOpsChangeSchema)
+});
+
+export const PagerDutyInputSchema = z.object({
+  serviceId: z.string().min(1),
+  lookbackHours: z.number().int().positive().default(168)
+});
+
+export const PagerDutyIncidentSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string().url().optional(),
+  status: z.string().optional(),
+  createdAt: z.string().optional(),
+  resolvedAt: z.string().optional()
+});
+
+export const PagerDutyOutputSchema = z.object({
+  incidents: z.array(PagerDutyIncidentSchema)
+});
+
+export const AiProviderConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("BEDROCK"),
+    region: z.string().min(1),
+    modelId: z.string().min(1)
+  }),
+  z.object({
+    type: z.literal("OLLAMA"),
+    host: z.string().min(1),
+    model: z.string().min(1)
+  }),
+  z.object({
+    type: z.literal("OPENAI"),
+    model: z.string().min(1)
+  })
+]);
+
+export const SynthesizeReportInputSchema = z.object({
+  rawContext: z.record(z.unknown()),
+  providerConfig: AiProviderConfigSchema
+});
+
+export const SynthesizeReportOutputSchema = z.object({
+  content: z.string().min(1),
+  provider: z.string().min(1)
+});
+
+export const SlackDeliveryInputSchema = z.object({
+  content: z.string().min(1),
+  webhookUrl: z.string().url().optional()
+});
+
+export const SlackDeliveryOutputSchema = z.object({
+  delivered: z.boolean(),
+  status: z.number().int()
+});
+
+export const LocalDeliveryInputSchema = z.object({
+  content: z.string().min(1),
+  outputDir: z.string().optional()
+});
+
+export const LocalDeliveryOutputSchema = z.object({
+  delivered: z.boolean(),
+  filePath: z.string().min(1)
+});
+
+export const WorkflowFlagsSchema = z.object({
+  enableLinearSource: z.boolean(),
+  enableGitSource: z.boolean(),
+  enablePagerDutySource: z.boolean(),
+  enableSlackDelivery: z.boolean()
+});
+
+export const OpsNarrativeRequestSchema = z.object({
+  linear: LinearInputSchema.optional(),
+  git: GitOpsInputSchema.optional(),
+  pagerDuty: PagerDutyInputSchema.optional(),
+  output: z.enum(["SLACK", "LOCAL"]),
+  providerConfig: AiProviderConfigSchema
+});
+
+export const OpsNarrativeResultSchema = z.object({
+  content: z.string(),
+  delivery: z.enum(["SLACK", "LOCAL"]),
+  artifacts: z.record(z.unknown()).optional()
+});

--- a/apps/harmony/src/ops-narrative/workflow.js
+++ b/apps/harmony/src/ops-narrative/workflow.js
@@ -1,0 +1,80 @@
+import { proxyActivities } from "@temporalio/workflow";
+import { OpsNarrativeRequestSchema, OpsNarrativeResultSchema } from "./schemas.js";
+
+const {
+  fetchLinearData,
+  fetchGitOpsData,
+  fetchPagerDutyData,
+  synthesizeReport,
+  sendSlackReport,
+  writeLocalReport,
+  getWorkflowFlags
+} = proxyActivities({
+  startToCloseTimeout: "5 minutes"
+});
+
+export async function runOpsNarrativeWorkflow(request) {
+  const payload = OpsNarrativeRequestSchema.parse(request);
+  const flags = await getWorkflowFlags();
+
+  const tasks = [];
+  const context = {};
+
+  if (flags.enableLinearSource && payload.linear) {
+    tasks.push({ key: "linear", promise: fetchLinearData(payload.linear) });
+  }
+
+  if (flags.enableGitSource && payload.git) {
+    tasks.push({ key: "git", promise: fetchGitOpsData(payload.git) });
+  }
+
+  if (flags.enablePagerDutySource && payload.pagerDuty) {
+    tasks.push({ key: "pagerDuty", promise: fetchPagerDutyData(payload.pagerDuty) });
+  }
+
+  const settled = await Promise.allSettled(tasks.map((task) => task.promise));
+  const normalized = settled.map((result, index) => {
+    const key = tasks[index].key;
+    if (result.status === "fulfilled") {
+      return { key, status: "fulfilled", value: result.value };
+    }
+    return { key, status: "rejected", reason: result.reason?.message ?? String(result.reason) };
+  });
+
+  normalized.forEach((entry, index) => {
+    if (entry.status === "fulfilled") {
+      context[entry.key] = entry.value;
+    }
+  });
+
+  context.results = normalized;
+
+  const report = await synthesizeReport({
+    rawContext: context,
+    providerConfig: payload.providerConfig
+  });
+
+  let delivery = payload.output;
+  const artifacts = {};
+
+  if (payload.output === "SLACK" && flags.enableSlackDelivery) {
+    try {
+      const slackResult = await sendSlackReport({ content: report.content });
+      artifacts.slack = slackResult;
+    } catch (error) {
+      const localResult = await writeLocalReport({ content: report.content });
+      artifacts.local = localResult;
+      delivery = "LOCAL";
+    }
+  } else {
+    const localResult = await writeLocalReport({ content: report.content });
+    artifacts.local = localResult;
+    delivery = "LOCAL";
+  }
+
+  return OpsNarrativeResultSchema.parse({
+    content: report.content,
+    delivery,
+    artifacts
+  });
+}

--- a/apps/harmony/src/workflow/run-local.js
+++ b/apps/harmony/src/workflow/run-local.js
@@ -1,17 +1,56 @@
 import { Connection, Client } from "@temporalio/client";
-import { runDurableAnalyzer } from "./workflows.js";
+import { runDurableAnalyzer, runOpsNarrativeWorkflow } from "./workflows.js";
 
-const connection = await Connection.connect();
+function resolveTemporalAddress() {
+  return process.env.TEMPORAL_ADDRESS ?? "localhost:7233";
+}
+
+function buildOpsNarrativeRequest() {
+  const raw = process.env.ONW_REQUEST_JSON;
+  if (raw) {
+    return JSON.parse(raw);
+  }
+
+  return {
+    linear: process.env.ONW_LINEAR_TEAM
+      ? { teamKey: process.env.ONW_LINEAR_TEAM }
+      : undefined,
+    git: process.env.ONW_GIT_PROVIDER && process.env.ONW_GIT_REPO
+      ? { providerType: process.env.ONW_GIT_PROVIDER, repoId: process.env.ONW_GIT_REPO }
+      : undefined,
+    pagerDuty: process.env.ONW_PD_SERVICE
+      ? { serviceId: process.env.ONW_PD_SERVICE }
+      : undefined,
+    output: process.env.ONW_OUTPUT ?? "LOCAL",
+    providerConfig: process.env.ONW_PROVIDER_CONFIG
+      ? JSON.parse(process.env.ONW_PROVIDER_CONFIG)
+      : { type: "OLLAMA", host: "http://localhost:11434", model: "llama3" }
+  };
+}
+
+const connection = await Connection.connect({ address: resolveTemporalAddress() });
 const client = new Client({ connection });
 
-const goal = process.env.HARMONY_GOAL ?? "Analyze repository";
-const repositoryUrl = process.env.HARMONY_REPO ?? "https://github.com/modelcontextprotocol/servers";
+const workflow = process.env.HARMONY_WORKFLOW ?? "durable-analyzer";
 
-const handle = await client.workflow.start(runDurableAnalyzer, {
-  taskQueue: "harmony",
-  workflowId: `harmony-${Date.now()}`,
-  args: [{ goal, repositoryUrl }]
-});
+let handle;
+if (workflow === "ops-narrative") {
+  const request = buildOpsNarrativeRequest();
+  handle = await client.workflow.start(runOpsNarrativeWorkflow, {
+    taskQueue: "harmony",
+    workflowId: `ops-narrative-${Date.now()}`,
+    args: [request]
+  });
+} else {
+  const goal = process.env.HARMONY_GOAL ?? "Analyze repository";
+  const repositoryUrl = process.env.HARMONY_REPO ?? "https://github.com/modelcontextprotocol/servers";
+
+  handle = await client.workflow.start(runDurableAnalyzer, {
+    taskQueue: "harmony",
+    workflowId: `harmony-${Date.now()}`,
+    args: [{ goal, repositoryUrl }]
+  });
+}
 
 const result = await handle.result();
 console.log(JSON.stringify(result, null, 2));

--- a/apps/harmony/src/workflow/worker.js
+++ b/apps/harmony/src/workflow/worker.js
@@ -1,14 +1,22 @@
+import "../instrumentation.js";
 import { Worker } from "@temporalio/worker";
+import { Connection } from "@temporalio/client";
 import * as activities from "./activities.js";
+import * as opsNarrativeActivities from "../ops-narrative/activities.js";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const workflowDir = dirname(fileURLToPath(import.meta.url));
 
+const connection = await Connection.connect({
+  address: process.env.TEMPORAL_ADDRESS ?? "localhost:7233"
+});
+
 const worker = await Worker.create({
   workflowsPath: resolve(workflowDir, "./workflows.js"),
-  activities,
-  taskQueue: "harmony"
+  activities: { ...activities, ...opsNarrativeActivities },
+  taskQueue: "harmony",
+  connection
 });
 
 await worker.run();

--- a/apps/harmony/src/workflow/workflows.js
+++ b/apps/harmony/src/workflow/workflows.js
@@ -1,5 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow";
 import { createInitialState } from "../agent/state.js";
+import { runOpsNarrativeWorkflow } from "../ops-narrative/workflow.js";
 
 const { planActivity, executeActivity, reviewActivity } = proxyActivities({
   startToCloseTimeout: "5 minutes"
@@ -14,3 +15,5 @@ export async function runDurableAnalyzer({ goal, repositoryUrl }) {
 
   return state;
 }
+
+export { runOpsNarrativeWorkflow };

--- a/apps/harmony/vitest.config.js
+++ b/apps/harmony/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.js", "src/**/*.spec.js"]
+  }
+});


### PR DESCRIPTION
### Motivation
- Traces were no-ops because the OpenTelemetry SDK was not being started, which prevents observability of worker activities and AI calls.
- The Dagger module did not model Temporal (and optional Ollama) as services, breaking the local emulation pattern required by the platform golden path.
- Ensure the Temporal worker boots telemetry before executing activities so spans are exported via OTLP to an external collector.
- Provide a reproducible Dagger `run-local` flow that binds services correctly for local end-to-end testing of the workflow.

### Description
- Bootstrapped the OpenTelemetry Node SDK and OTLP exporter in `apps/harmony/src/instrumentation.js` and imported it at the top of the worker entrypoint via `import "../instrumentation.js"` so telemetry is initialized before activities run.
- Updated `apps/harmony/src/workflow/worker.js` to connect to Temporal using `Connection.connect({ address })` and merged ops-narrative activities into the worker activities map so the workflow can be executed by the same worker.
- Reworked the Dagger module at `apps/harmony/dagger/main.ts` to provide a `runLocal` entry that starts a Temporal dev service and an optional Ollama service, binds them as sidecars, and runs the worker and client with correct `TEMPORAL_ADDRESS` and `ONW_PROVIDER_CONFIG` injection.
- Added OTel SDK dependencies to `apps/harmony/package.json`, added `vitest` config and tests under `apps/harmony/src/ops-narrative/__tests__/activities.test.js`, and documented the new `dagger call run-local` invocation and `OTEL_EXPORTER_OTLP_ENDPOINT` in `apps/harmony/README.md`.

### Testing
- Unit tests were added under `apps/harmony/src/ops-narrative/__tests__/activities.test.js`, but `pnpm -C apps/harmony test:vitest` was not executed in this environment due to registry access being blocked.
- No automated Dagger `run-local` invocation was executed in CI here because the environment cannot install dependencies or run container engines in this host.
- Package changes compile-time validation was not executed here because dependency installation (`pnpm install`) was blocked by registry permissions.
- Manual smoke: the worker entrypoint was updated to import the instrumentation file and the code changes were committed, but automated test runs and end-to-end Dagger emulation must be executed in an environment with registry access and Docker/Dagger engine available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645df102048333ba092c7ff97e29ba)