### PR TITLE
Remove OpenAI-specific naming from embedding config and provider

### DIFF
--- a/apps/harmony/README.md
+++ b/apps/harmony/README.md
@@ -52,6 +52,27 @@ HARMONY_REPO="https://github.com/modelcontextprotocol/servers" pnpm start:client
 
 The workflow runs the Plan → Execute → Review steps and outputs the resulting state, including the README contents, file tree, and review notes.
 
+### Tool selection
+
+Tool selection is backed by a vector index stored in Postgres/pgvector. A dedicated ingestion step embeds MCP tool definitions with `text-embedding-3-small` and stores them in the `mcp_tool_index` table. At runtime, the plan step embeds the user goal and retrieves the top matches from the vector index.
+
+#### Ingest tools
+
+Provide a Postgres connection string and embedding provider configuration, then run:
+
+```bash
+cd apps/harmony
+TOOL_INDEX_DATABASE_URL="postgres://user:pass@localhost:5432/harmony" \
+EMBEDDING_API_KEY="..." \
+pnpm start:ingest-tools
+```
+
+Optional environment variables:
+
+- `EMBEDDING_MODEL` (defaults to `text-embedding-3-small`)
+- `EMBEDDING_BASE_URL` (defaults to `https://api.openai.com/v1`)
+- `MCP_SERVER_ID` (defaults to `local-stdio`)
+
 ## Troubleshooting
 
 - **Dagger connection errors**: ensure the Dagger engine container is running and the Docker socket is accessible.

--- a/apps/harmony/package.json
+++ b/apps/harmony/package.json
@@ -8,7 +8,8 @@
     "start:mcp": "node src/mcp/server.js",
     "start:worker": "node src/workflow/worker.js",
     "start:client": "node src/workflow/run-local.js",
-    "test": "node --test"
+    "start:ingest-tools": "node src/tool-index/ingest.js",
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@dagger.io/dagger": "^0.11.1",
@@ -17,6 +18,7 @@
     "@temporalio/client": "^1.10.4",
     "@temporalio/worker": "^1.10.4",
     "@temporalio/workflow": "^1.10.4",
+    "pg": "^8.13.0",
     "zod": "^4.1.5"
   }
 }

--- a/apps/harmony/src/agent/graph.js
+++ b/apps/harmony/src/agent/graph.js
@@ -2,14 +2,13 @@ import { END, START, StateGraph } from "@langchain/langgraph";
 import { AgentStateSchema, createInitialState } from "./state.js";
 import { buildPlan } from "./plan.js";
 import { reviewAnalysis } from "./review.js";
-import { analyzeRepository, createMcpClient, listTools } from "../mcp/client.js";
+import { analyzeRepository, createMcpClient } from "../mcp/client.js";
+import { retrieveRelevantTools } from "../tool-index/retrieval.js";
 
 const GraphState = AgentStateSchema;
 
 async function planNode(state) {
-  const client = await createMcpClient();
-  const tools = await listTools(client);
-  await client.close();
+  const tools = await retrieveRelevantTools(state.goal);
 
   return {
     ...state,

--- a/apps/harmony/src/tool-index/config.js
+++ b/apps/harmony/src/tool-index/config.js
@@ -1,0 +1,32 @@
+export const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+export const DEFAULT_TOOL_LIMIT = 5;
+export const DEFAULT_EMBEDDING_BASE_URL = "https://api.openai.com/v1";
+export const EMBEDDING_DIMENSIONS = 1536;
+
+export function getDatabaseUrl() {
+  const url = process.env.TOOL_INDEX_DATABASE_URL;
+  if (!url) {
+    throw new Error("TOOL_INDEX_DATABASE_URL is required for tool retrieval");
+  }
+  return url;
+}
+
+export function getEmbeddingApiKey() {
+  const apiKey = process.env.EMBEDDING_API_KEY;
+  if (!apiKey) {
+    throw new Error("EMBEDDING_API_KEY is required for tool embeddings");
+  }
+  return apiKey;
+}
+
+export function getEmbeddingModel() {
+  return process.env.EMBEDDING_MODEL ?? DEFAULT_EMBEDDING_MODEL;
+}
+
+export function getEmbeddingBaseUrl() {
+  return process.env.EMBEDDING_BASE_URL ?? DEFAULT_EMBEDDING_BASE_URL;
+}
+
+export function getMcpServerId() {
+  return process.env.MCP_SERVER_ID ?? "local-stdio";
+}

--- a/apps/harmony/src/tool-index/document.js
+++ b/apps/harmony/src/tool-index/document.js
@@ -1,0 +1,13 @@
+export function toolDefinitionId(serverId, toolName) {
+  return `${serverId}:${toolName}`;
+}
+
+export function buildToolDocument(definition) {
+  const name = definition?.name ?? "";
+  const description = definition?.description ?? "";
+  const schema = definition?.inputSchema
+    ? JSON.stringify(definition.inputSchema)
+    : "";
+
+  return [name, description, schema].filter(Boolean).join("\n");
+}

--- a/apps/harmony/src/tool-index/infra/http-embedding-provider.js
+++ b/apps/harmony/src/tool-index/infra/http-embedding-provider.js
@@ -1,0 +1,41 @@
+export class HttpEmbeddingProvider {
+  constructor({ apiKey, baseUrl, model }) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+    this.model = model;
+  }
+
+  async embedText(text) {
+    if (!this.apiKey) {
+      throw new Error("Embedding provider requires apiKey");
+    }
+
+    const url = new URL("/embeddings", this.baseUrl);
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({
+        model: this.model,
+        input: text
+      })
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`Embedding request failed: ${response.status} ${detail}`);
+    }
+
+    const payload = await response.json();
+    const embedding = payload?.data?.[0]?.embedding;
+
+    if (!Array.isArray(embedding)) {
+      throw new Error("Embedding response missing vector data");
+    }
+
+    return embedding;
+  }
+}

--- a/apps/harmony/src/tool-index/infra/postgres-tool-store.js
+++ b/apps/harmony/src/tool-index/infra/postgres-tool-store.js
@@ -1,0 +1,91 @@
+import pg from "pg";
+
+const { Pool } = pg;
+
+export class PostgresToolStore {
+  constructor({ connectionString, dimensions }) {
+    this.pool = new Pool({ connectionString });
+    this.dimensions = dimensions;
+  }
+
+  async ensureSchema() {
+    await this.pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await this.pool.query(
+      `CREATE TABLE IF NOT EXISTS mcp_tool_index (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        input_schema JSONB NOT NULL,
+        mcp_server_id TEXT NOT NULL,
+        embedding vector(${this.dimensions}) NOT NULL,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`
+    );
+  }
+
+  async upsertToolDefinition(definition, embedding) {
+    const query = `
+      INSERT INTO mcp_tool_index (
+        id,
+        name,
+        description,
+        input_schema,
+        mcp_server_id,
+        embedding,
+        updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, NOW())
+      ON CONFLICT (id)
+      DO UPDATE SET
+        name = EXCLUDED.name,
+        description = EXCLUDED.description,
+        input_schema = EXCLUDED.input_schema,
+        mcp_server_id = EXCLUDED.mcp_server_id,
+        embedding = EXCLUDED.embedding,
+        updated_at = NOW()
+    `;
+
+    const values = [
+      definition.id,
+      definition.name,
+      definition.description,
+      definition.inputSchema,
+      definition.mcpServerId,
+      this.#toSqlVector(embedding)
+    ];
+
+    await this.pool.query(query, values);
+  }
+
+  async querySimilarTools(embedding, { limit }) {
+    const result = await this.pool.query(
+      `
+        SELECT id, name, description, input_schema, mcp_server_id
+        FROM mcp_tool_index
+        ORDER BY embedding <-> $1
+        LIMIT $2
+      `,
+      [this.#toSqlVector(embedding), limit]
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      inputSchema: row.input_schema,
+      mcpServerId: row.mcp_server_id
+    }));
+  }
+
+  async close() {
+    await this.pool.end();
+  }
+
+  #toSqlVector(vector) {
+    if (!Array.isArray(vector)) {
+      throw new Error("Embedding vector must be an array");
+    }
+
+    return `[${vector.join(",")}]`;
+  }
+}

--- a/apps/harmony/src/tool-index/ingest.js
+++ b/apps/harmony/src/tool-index/ingest.js
@@ -1,0 +1,47 @@
+import { createMcpClient, listTools } from "../mcp/client.js";
+import {
+  EMBEDDING_DIMENSIONS,
+  getDatabaseUrl,
+  getEmbeddingBaseUrl,
+  getEmbeddingModel,
+  getMcpServerId,
+  getEmbeddingApiKey
+} from "./config.js";
+import { ingestToolDefinitions } from "./services.js";
+import { HttpEmbeddingProvider } from "./infra/http-embedding-provider.js";
+import { PostgresToolStore } from "./infra/postgres-tool-store.js";
+
+export async function ingestTools() {
+  const client = await createMcpClient();
+  const tools = await listTools(client);
+  await client.close();
+
+  const serverId = getMcpServerId();
+  const toolStore = new PostgresToolStore({
+    connectionString: getDatabaseUrl(),
+    dimensions: EMBEDDING_DIMENSIONS
+  });
+  const embeddingProvider = new HttpEmbeddingProvider({
+    apiKey: getEmbeddingApiKey(),
+    baseUrl: getEmbeddingBaseUrl(),
+    model: getEmbeddingModel()
+  });
+
+  try {
+    await ingestToolDefinitions({
+      tools,
+      toolStore,
+      embeddingProvider,
+      serverId
+    });
+  } finally {
+    await toolStore.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  ingestTools().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/harmony/src/tool-index/interfaces.js
+++ b/apps/harmony/src/tool-index/interfaces.js
@@ -1,0 +1,14 @@
+/**
+ * @typedef {object} EmbeddingProvider
+ * @property {(text: string) => Promise<number[]>} embedText
+ */
+
+/**
+ * @typedef {object} ToolStore
+ * @property {() => Promise<void>} ensureSchema
+ * @property {(definition: object, embedding: number[]) => Promise<void>} upsertToolDefinition
+ * @property {(embedding: number[], options: { limit: number }) => Promise<object[]>} querySimilarTools
+ * @property {() => Promise<void>} close
+ */
+
+export const __interfaces = {};

--- a/apps/harmony/src/tool-index/retrieval.js
+++ b/apps/harmony/src/tool-index/retrieval.js
@@ -1,0 +1,34 @@
+import {
+  DEFAULT_TOOL_LIMIT,
+  EMBEDDING_DIMENSIONS,
+  getDatabaseUrl,
+  getEmbeddingBaseUrl,
+  getEmbeddingModel,
+  getEmbeddingApiKey
+} from "./config.js";
+import { retrieveRelevantTools as retrieveFromServices } from "./services.js";
+import { HttpEmbeddingProvider } from "./infra/http-embedding-provider.js";
+import { PostgresToolStore } from "./infra/postgres-tool-store.js";
+
+export async function retrieveRelevantTools(query, { limit = DEFAULT_TOOL_LIMIT } = {}) {
+  const toolStore = new PostgresToolStore({
+    connectionString: getDatabaseUrl(),
+    dimensions: EMBEDDING_DIMENSIONS
+  });
+  const embeddingProvider = new HttpEmbeddingProvider({
+    apiKey: getEmbeddingApiKey(),
+    baseUrl: getEmbeddingBaseUrl(),
+    model: getEmbeddingModel()
+  });
+
+  try {
+    return await retrieveFromServices({
+      query,
+      toolStore,
+      embeddingProvider,
+      limit
+    });
+  } finally {
+    await toolStore.close();
+  }
+}

--- a/apps/harmony/src/tool-index/services.js
+++ b/apps/harmony/src/tool-index/services.js
@@ -1,0 +1,26 @@
+import { buildToolDocument, toolDefinitionId } from "./document.js";
+
+export async function ingestToolDefinitions({ tools, toolStore, embeddingProvider, serverId }) {
+  await toolStore.ensureSchema();
+
+  for (const tool of tools) {
+    const definition = {
+      id: toolDefinitionId(serverId, tool.name),
+      name: tool.name,
+      description: tool.description ?? "",
+      inputSchema: tool.inputSchema ?? {},
+      mcpServerId: serverId
+    };
+
+    const document = buildToolDocument(definition);
+    const embedding = await embeddingProvider.embedText(document);
+    await toolStore.upsertToolDefinition(definition, embedding);
+  }
+}
+
+export async function retrieveRelevantTools({ query, toolStore, embeddingProvider, limit }) {
+  await toolStore.ensureSchema();
+
+  const embedding = await embeddingProvider.embedText(query);
+  return toolStore.querySimilarTools(embedding, { limit });
+}

--- a/apps/harmony/src/workflow/activities.js
+++ b/apps/harmony/src/workflow/activities.js
@@ -1,13 +1,12 @@
 import { AgentStateSchema, ToolResultSchema } from "../agent/state.js";
 import { buildPlan } from "../agent/plan.js";
 import { reviewAnalysis } from "../agent/review.js";
-import { analyzeRepository, createMcpClient, listTools } from "../mcp/client.js";
+import { analyzeRepository, createMcpClient } from "../mcp/client.js";
+import { retrieveRelevantTools } from "../tool-index/retrieval.js";
 
 export async function planActivity(state) {
   const parsed = AgentStateSchema.parse(state);
-  const client = await createMcpClient();
-  const tools = await listTools(client);
-  await client.close();
+  const tools = await retrieveRelevantTools(parsed.goal);
 
   return {
     ...parsed,

--- a/apps/harmony/test/agent.test.js
+++ b/apps/harmony/test/agent.test.js
@@ -1,5 +1,4 @@
-import test from "node:test";
-import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
 import { buildPlan } from "../src/agent/plan.js";
 import { reviewAnalysis } from "../src/agent/review.js";
 
@@ -12,13 +11,15 @@ const baseState = {
   notes: []
 };
 
-test("buildPlan requires analyze_repo tool", () => {
-  const tools = [{ name: "analyze_repo" }];
-  const plan = buildPlan(baseState, tools);
-  assert.ok(plan.length >= 2);
-});
+describe("agent planning", () => {
+  it("buildPlan requires analyze_repo tool", () => {
+    const tools = [{ name: "analyze_repo" }];
+    const plan = buildPlan(baseState, tools);
+    expect(plan.length).toBeGreaterThanOrEqual(2);
+  });
 
-test("reviewAnalysis flags missing README", () => {
-  const notes = reviewAnalysis({ readme: "", tree: "./README.md\n./src/index.js" });
-  assert.ok(notes.some((note) => note.includes("README missing")));
+  it("reviewAnalysis flags missing README", () => {
+    const notes = reviewAnalysis({ readme: "", tree: "./README.md\n./src/index.js" });
+    expect(notes.some((note) => note.includes("README missing"))).toBe(true);
+  });
 });

--- a/apps/harmony/test/tool-index.test.js
+++ b/apps/harmony/test/tool-index.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { buildToolDocument, toolDefinitionId } from "../src/tool-index/document.js";
+import { ingestToolDefinitions, retrieveRelevantTools } from "../src/tool-index/services.js";
+
+const definition = {
+  name: "restart_service",
+  description: "Restart a service",
+  inputSchema: { type: "object", properties: { service: { type: "string" } } }
+};
+
+describe("tool-index helpers", () => {
+  it("toolDefinitionId builds a stable id", () => {
+    expect(toolDefinitionId("aws-mcp", "restart_service")).toBe("aws-mcp:restart_service");
+  });
+
+  it("buildToolDocument concatenates name, description, and schema", () => {
+    const doc = buildToolDocument(definition);
+    expect(doc).toContain("restart_service");
+    expect(doc).toContain("Restart a service");
+    expect(doc).toContain("\"service\"");
+  });
+});
+
+describe("tool-index services", () => {
+  const toolStore = {
+    ensureSchema: vi.fn(),
+    upsertToolDefinition: vi.fn(),
+    querySimilarTools: vi.fn(),
+    close: vi.fn()
+  };
+  const embeddingProvider = {
+    embedText: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ingestToolDefinitions stores embeddings for each tool", async () => {
+    embeddingProvider.embedText.mockResolvedValue([0.1, 0.2]);
+
+    await ingestToolDefinitions({
+      tools: [definition],
+      toolStore,
+      embeddingProvider,
+      serverId: "aws-mcp"
+    });
+
+    expect(toolStore.ensureSchema).toHaveBeenCalled();
+    expect(embeddingProvider.embedText).toHaveBeenCalled();
+    expect(toolStore.upsertToolDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "aws-mcp:restart_service",
+        name: "restart_service"
+      }),
+      [0.1, 0.2]
+    );
+  });
+
+  it("retrieveRelevantTools queries the store using embedded query", async () => {
+    toolStore.querySimilarTools.mockResolvedValue([{ name: "restart_service" }]);
+    embeddingProvider.embedText.mockResolvedValue([0.5, 0.6]);
+
+    const results = await retrieveRelevantTools({
+      query: "fix server",
+      toolStore,
+      embeddingProvider,
+      limit: 3
+    });
+
+    expect(toolStore.ensureSchema).toHaveBeenCalled();
+    expect(embeddingProvider.embedText).toHaveBeenCalledWith("fix server");
+    expect(toolStore.querySimilarTools).toHaveBeenCalledWith([0.5, 0.6], { limit: 3 });
+    expect(results).toEqual([{ name: "restart_service" }]);
+  });
+});

--- a/apps/harmony/vitest.config.ts
+++ b/apps/harmony/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js']
+  }
+});


### PR DESCRIPTION
### Motivation
- Remove vendor-specific naming and symbols from the embedding configuration and provider to make the module vendor-neutral.
- Provide a generic HTTP embedding provider abstraction for any OpenAI-compatible or other embedding HTTP endpoints.
- Ensure ingestion and retrieval wiring use the generic provider and env variables rather than provider-branded names.
- Add tests and docs to validate ingestion/retrieval behavior and to document the new env variables.

### Description
- Renamed config getters and environment variables to use `EMBEDDING_*` and added `getEmbeddingApiKey`, `getEmbeddingModel`, and `getEmbeddingBaseUrl` in `src/tool-index/config.js`.
- Replaced the provider class with a generic `HttpEmbeddingProvider` (`src/tool-index/infra/http-embedding-provider.js`) and updated ingestion/retrieval wiring to use it (`src/tool-index/ingest.js`, `src/tool-index/retrieval.js`).
- Added tool-index core modules including `services.js`, `document.js`, `interfaces.js`, and a Postgres-backed store `infra/postgres-tool-store.js`, and updated agent/workflow callers to use `retrieveRelevantTools`.
- Updated docs and package scripts, added `vitest.config.ts`, and added unit tests in `test/tool-index.test.js` covering ingestion and retrieval behavior.

### Testing
- Ran the project test suite with `pnpm -C apps/harmony test` which completed successfully.
- Vitest reported: `Test Files  2 passed (2)` and `Tests  6 passed (6)`.
- New unit tests assert that `ingestToolDefinitions` calls `embeddingProvider.embedText` and `toolStore.upsertToolDefinition`.
- New unit tests assert that `retrieveRelevantTools` embeds the raw query via `embeddingProvider.embedText` and calls `toolStore.querySimilarTools`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696420c1ad708333bb3448a2718c6492)